### PR TITLE
Name of TPR file can now contain the file extension.

### DIFF
--- a/changelog/32.feature
+++ b/changelog/32.feature
@@ -1,0 +1,1 @@
+GROMACS .tpr files can now be referenced with and without the file extension.

--- a/mdbenchmark/generate.py
+++ b/mdbenchmark/generate.py
@@ -42,9 +42,12 @@ def write_bench(top, tmpl, nodes, gpu, module, name, host, time):
             'started': False
         })
 
-    # copy input files
-    tpr = '{}.tpr'.format(name)
+    fn, ext = os.path.splitext(name)
 
+    if not ext:
+        ext = '.tpr'
+
+    tpr = fn + ext
     if not os.path.exists(tpr):
         raise click.FileError(
             tpr, hint='File does not exist or is not readable.')
@@ -70,11 +73,7 @@ def write_bench(top, tmpl, nodes, gpu, module, name, host, time):
 
 @cli.command()
 @click.option(
-    '-n',
-    '--name',
-    help='name of tpr file',
-    default='md',
-    show_default=True)
+    '-n', '--name', help='name of tpr file', default='md', show_default=True)
 @click.option(
     '-g', '--gpu', is_flag=True, help='run on gpu as well', show_default=True)
 @click.option('-m', '--module', help='gromacs module to use', multiple=True)

--- a/mdbenchmark/tests/test_generate.py
+++ b/mdbenchmark/tests/test_generate.py
@@ -20,19 +20,23 @@
 import os
 
 import pytest
-
-from mdbenchmark.ext.click_test import cli_runner
 from mdbenchmark import cli
+from mdbenchmark.ext.click_test import cli_runner
 
 
-def test_generate(cli_runner, tmpdir):
+@pytest.mark.parametrize('tpr_file', ('protein.tpr', 'protein'))
+def test_generate(cli_runner, tmpdir, tpr_file):
+    """Run an integration test on the generate function.
+
+    Make sure that we accept both `protein` and `protein.tpr` as input files.
+    """
     with tmpdir.as_cwd():
         with open('protein.tpr', 'w') as fh:
             fh.write('This is a dummy tpr ;)')
 
         result = cli_runner.invoke(cli.cli, [
             'generate', '--module=gromacs/2016', '--host=draco',
-            '--max-nodes=4', '--gpu', '--name=protein'
+            '--max-nodes=4', '--gpu', '--name={}'.format(tpr_file)
         ])
         assert result.exit_code == 0
         assert os.path.exists('draco_gromacs')


### PR DESCRIPTION
Fixes #31.

Changes made in this Pull Request:
 - Name of TPR file can now contain the file extension.


PR Checklist
------------
 - [x] CHANGELOG updated (added [news fragment](https://github.com/hawkowl/towncrier#news-fragments) into changelog directory)?
 - [x] Issue raised/referenced?