### PR TITLE
Pin numpy to versions below 1.14

### DIFF
--- a/changelog/34.bugfix
+++ b/changelog/34.bugfix
@@ -1,0 +1,1 @@
+Pin numpy to >=1.8,<1.14. This removes the FutureWarning thrown by h5py.

--- a/setup.py
+++ b/setup.py
@@ -17,16 +17,18 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with MDBenchmark.  If not, see <http://www.gnu.org/licenses/>.
-from setuptools import setup, find_packages
+import io
 import os
 import re
-import io
+
+from setuptools import find_packages, setup
 
 
 # modified from https://stackoverflow.com/a/41110107/2207958
 def get_property(prop, project):
     with open(project + '/__init__.py') as fh:
-        result = re.search(r'{}\s*=\s*[\'"]([^\'"]*)[\'"]'.format(prop), fh.read())
+        result = re.search(r'{}\s*=\s*[\'"]([^\'"]*)[\'"]'.format(prop),
+                           fh.read())
     return result.group(1)
 
 
@@ -60,7 +62,7 @@ setup(
     packages=find_packages(),
     package_data={'mdbenchmark': ['templates/*']},
     install_requires=[
-        'numpy>=1.8',
+        'numpy>=1.8,<1.14',
         'mdsynthesis',
         'click',
         'jinja2',


### PR DESCRIPTION
Changes made in this Pull Request:
 - Pin numpy to: `numpy>=1.8,<1.14`. `h5py` currently throws some ugly errors, when using `numpy==1.14`. For reference, see h5py/h5py#961 and numpy/numpy#9505.

That is the error that otherwise shows up everytime `mdbenchmark` is run:
```bash
$ mdbenchmark --version
/home/mischi/.local/lib/python3.6/site-packages/h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.
  from ._conv import register_converters as _register_converters
mdbenchmark, version 1.1.1
```

PR Checklist
------------
 - [x] CHANGELOG updated (added [news fragment](https://github.com/hawkowl/towncrier#news-fragments) into changelog directory)?
 - ~[ ] Issue raised/referenced?~

