### PR TITLE
Suppress h5py FutureWarning

### DIFF
--- a/changelog/35.bugfix
+++ b/changelog/35.bugfix
@@ -1,0 +1,1 @@
+Suppress FutureWarning caused by ``h5py``.

--- a/mdbenchmark/__init__.py
+++ b/mdbenchmark/__init__.py
@@ -17,6 +17,16 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with MDBenchmark.  If not, see <http://www.gnu.org/licenses/>.
-from . import analyze, generate, submit
+import warnings
 
-__version__ = '1.1.1'
+# Get rid of the h5py FutureWarning
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        message='.*Conversion of the second.*',
+        action='ignore',
+        category=FutureWarning,
+        module='h5py')
+
+    from . import analyze, generate, submit
+
+    __version__ = '1.1.1'


### PR DESCRIPTION
Changes made in this Pull Request:
 - Suppress the `FutureWarning` caused by `h5py`. See: h5py/h5py#961.

Replaces #34. Fixes #33.

PR Checklist
------------
 - [x] CHANGELOG updated (added [news fragment](https://github.com/hawkowl/towncrier#news-fragments) into changelog directory)?
 - ~[ ] Issue raised/referenced?~

