### PR TITLE
Update plotting interface

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@
 .. image:: https://img.shields.io/pypi/l/mdbenchmark.svg
     :target: https://pypi.python.org/pypi/mdbenchmark
 
-.. image:: https://travis-ci.org/bio-phys/MDBenchmark.svg?branch=master
+.. image:: https://travis-ci.org/bio-phys/MDBenchmark.svg?branch=develop
     :target: https://travis-ci.org/bio-phys/MDBenchmark
 
 .. image:: https://codecov.io/gh/bio-phys/MDBenchmark/branch/master/graph/badge.svg
@@ -51,19 +51,19 @@ You can install ``mdbenchmark`` via ``pip`` or ``conda``:
 
     $ conda install -c conda-forge mdbenchmark
 
-Usage with a virtual environments
----------------------------------
+Usage with a virtual environment
+--------------------------------
 
 We recommend to install the package inside a `conda environment`_. This can
 easily be done with ``conda``. The following commands create an environment
-called ``benchmark`` and then installs ``mdbenchmark`` and its dependencies.
+called ``benchmark`` and then installs ``mdbenchmark`` with its dependencies.
 
 .. code::
 
     $ conda create -n benchmark
-    $ conda install -n benchmark -c conda-forge mdsynthesis click mdbenchmark
+    $ conda install -n benchmark -c conda-forge mdbenchmark
 
-Before every usage of ``mdbenchmark``, you need to first activate the conda
+Before every usage of ``mdbenchmark``, you need to activate the conda
 environment. After doing this once, you can use the tool for the whole duration
 of your shell session.
 
@@ -74,16 +74,17 @@ of your shell session.
    $ mdbenchmark
    Usage: mdbenchmark [OPTIONS] COMMAND [ARGS]...
 
-     Generate and run benchmark jobs for GROMACS simulations.
+     Generate, run and analyze benchmarks of molecular dynamics simulations.
 
    Options:
      --version  Show the version and exit.
      --help     Show this message and exit.
 
    Commands:
-     analyze   analyze finished benchmark.
-     generate  Generate benchmark queuing jobs.
-     submit    Start benchmark simulations.
+     analyze   Analyze finished benchmarks.
+     generate  Generate benchmarks simulations from the CLI.
+     plot      Generate plots from csv files
+     submit    Submit benchmarks to queuing system.
 
 Features
 ========
@@ -117,13 +118,6 @@ To run benchmarks on GPUs simply add the ``--gpu`` flag:
 
     $ mdbenchmark generate --name protein --module gromacs/5.1.4-plumed2.3 --max-nodes 10 --gpu
 
-You can also create benchmarks for different versions of GROMACS:
-
-.. code::
-
-    $ mdbenchmark generate --name protein --module gromacs/5.1.4-plumed2.3 --module gromacs/2016.4-plumed2.3 --max-nodes 10 --gpu
-
-
 Benchmark generation for NAMD
 -----------------------------
 
@@ -156,15 +150,33 @@ probably named differently on the host of your choice. Using the ``--gpu``
 option on non-GPU builds of NAMD may lead to poorer performance and erroneous
 results.
 
-Usage with multiple modules
----------------------------
+Skipping module name validation
+-------------------------------
 
-It is possible to generate benchmarks for different MD engines with a single
-command:
+We try to validate the module name provided during benchmark generation. If you
+want to skip the module name validation, you can do so easily with the
+``--skip-validation`` flag:
 
 .. code::
 
-    $ mdbenchmark generate --name protein --module namd/2.12 --module gromacs/2016.3 --max-nodes 10
+    $ mdbenchmark generate --name protein --module gromacs/dummy --skip-validation
+
+**Note:** We currently only support the MD engines ``gromacs`` and ``namd``.
+Even if you skip the module name validation, our system needs to know that you
+plan to use either of the two engines, so you need to provide a dummy module
+name when skipping the validation, e.g., ``gromacs/abc`` or ``namd/123`` (the
+part after the forward slash ``/`` is arbitrary).
+
+Usage with multiple modules
+---------------------------
+
+It is possible to generate benchmarks for different MD engines or different
+versions of the same engine with a single command:
+
+.. code::
+
+    $ mdbenchmark generate --name protein --module namd/2.12 --module gromacs/2016.3
+    $ mdbenchmark generate --name protein --module gromacs/5.1.4-plumed2.3 --module gromacs/2016.4-plumed2.3
 
 Benchmark submission
 --------------------
@@ -191,9 +203,10 @@ will produce a ``.csv`` output file or a plot for direct usage (via the
 ``--plot`` option).
 
 **Note:** The plotting function currently only allows to plot a CPU and GPU
-benchmark from the same module. We are working on fixing this. If you want to
-compare different modules with each other, either use the ``--directory`` option
-to generate separate plots or create your own plot from the provided CSV file.
+benchmark from the same module. This will be fixed with version 2.0.0 (see
+``develop`` branch). If you want to compare different modules with each other,
+either use the ``--directory`` option to generate separate plots or create your
+own plot from the provided CSV file.
 
 .. code::
 

--- a/changelog/52.feature
+++ b/changelog/52.feature
@@ -1,0 +1,8 @@
+Updated plotting interface. `mdbenchmark analyze --plot` is not deprecated. Use `mdbenchmark plot` instead.
+
+The new workflow for plotting data is as follows:
+
+1) Use `mdbenchmark analyze` to generate a CSV output file.
+2) Use `mdbenchmark plot --csv name_of_generated_file.csv` to plot the data.
+
+Consult `mdbenchmark <command> --help` for options to filter your data accordingly.

--- a/mdbenchmark/__init__.py
+++ b/mdbenchmark/__init__.py
@@ -33,6 +33,6 @@ with warnings.catch_warnings():
         category=UserWarning,
         module='MDAnalysis')
 
-    from . import analyze, generate, submit
+    from . import analyze, generate, submit, plot
 
     __version__ = '1.3.2'

--- a/mdbenchmark/analyze.py
+++ b/mdbenchmark/analyze.py
@@ -18,13 +18,17 @@
 # You should have received a copy of the GNU General Public License
 # along with MDBenchmark.  If not, see <http://www.gnu.org/licenses/>.
 import click
+import matplotlib.pyplot as plt
 import mdsynthesis as mds
 import numpy as np
 import pandas as pd
+from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
+from matplotlib.figure import Figure
 
 from . import console
 from .cli import cli
 from .mdengines import detect_md_engine, utils
+from .plot import plot_line
 from .utils import generate_output_name
 
 
@@ -97,20 +101,27 @@ def analyze(directory, plot, ncores, output_name):
     df.to_csv(output_name)
 
     if plot:
-        raise NotImplemented
-        # df = pd.read_csv(output_name)
+        console.warn(
+            'This feature is now outdated.'
+            'Please use mdbenchmark plot to access all plotting features'
+            'Future versions will not support this feature anymore.')
 
-        # # We only support plotting of benchmark systems from equal hosts /
-        # # with equal settings
-        # uniqueness = df.apply(lambda x: x.nunique())
-        # if uniqueness['gromacs'] > 1 or uniqueness['host'] > 1:
-        #     console.error(
-        #         'Cannot plot benchmarks for more than one GROMACS module '
-        #         'and/or host.')
+        fig = Figure()
+        FigureCanvas(fig)
+        ax = fig.add_subplot(111)
 
-        # # Fail if we have no values at all. This should be some edge case when
-        # # a user fumbles around with the datreant categories
-        # if df['gpu'].empty and df[~df['gpu']].empty:
-        #     console.error('There is no data to plot.')
+        df = pd.read_csv(output_name)
 
-        # plot_analysis(df, ncores)
+        df_sel = 'nodes'
+        gb = df.groupby(['gpu', 'module', 'host'])
+        groupby = ['gpu', 'module', 'host']
+        for key, df in gb:
+            label = ' '.join(['{}={}'.format(n, v) for n, v in zip(groupby, key)])
+            plot_line(df=df, df_sel=df_sel, ax=ax, label=label)
+
+        ax.set_xlabel('Number of Nodes')
+        ax.set_ylabel('Performance [ns/day]')
+        ax.legend()
+
+        fig.tight_layout()
+        fig.savefig('runtimes.pdf', format='pdf')

--- a/mdbenchmark/analyze.py
+++ b/mdbenchmark/analyze.py
@@ -54,11 +54,8 @@ plt.switch_backend('agg')
     'benchmarks log file.',
     show_default=True)
 @click.option(
-    '-o',
-    '--output-name',
-    default=None,
-    help="Name of the output .csv file.",
-    type=str)
+    "-o", "--output-name", default=None, help="Name of the output CSV file.", type=str
+)
 def analyze(directory, plot, ncores, output_name):
     """Analyze finished benchmarks."""
     bundle = mds.discover(directory)

--- a/mdbenchmark/analyze.py
+++ b/mdbenchmark/analyze.py
@@ -103,7 +103,8 @@ def analyze(directory, plot, ncores, output_name):
     df.to_csv(output_name)
 
     if plot:
-        console.warn('DEPECATED Please use \'{}\' in the future', 'mdbenchmark plot')
+        console.warn('This feature is deprecated. Please use \'{}\' in the future.',
+                     'mdbenchmark plot')
 
         fig = Figure()
         FigureCanvas(fig)

--- a/mdbenchmark/analyze.py
+++ b/mdbenchmark/analyze.py
@@ -28,7 +28,7 @@ from matplotlib.figure import Figure
 from . import console
 from .cli import cli
 from .mdengines import detect_md_engine, utils
-from .plot import plot_line
+from .plot import plot_over_group
 from .utils import generate_output_name
 
 
@@ -101,27 +101,15 @@ def analyze(directory, plot, ncores, output_name):
     df.to_csv(output_name)
 
     if plot:
-        console.warn(
-            'This feature is now outdated.'
-            'Please use mdbenchmark plot to access all plotting features'
-            'Future versions will not support this feature anymore.')
+        console.warn('DEPECATED Please use \'{}\' in the future', 'mdbenchmark plot')
 
         fig = Figure()
         FigureCanvas(fig)
         ax = fig.add_subplot(111)
 
         df = pd.read_csv(output_name)
-
-        df_sel = 'nodes'
-        gb = df.groupby(['gpu', 'module', 'host'])
-        groupby = ['gpu', 'module', 'host']
-        for key, df in gb:
-            label = ' '.join(['{}={}'.format(n, v) for n, v in zip(groupby, key)])
-            plot_line(df=df, df_sel=df_sel, ax=ax, label=label)
-
-        ax.set_xlabel('Number of Nodes')
-        ax.set_ylabel('Performance [ns/day]')
-        ax.legend()
+        ax = plot_over_group(df, plot_cores=False, ax=ax)
+        lgd = ax.legend(loc='upper center', bbox_to_anchor=(0.5, -0.175))
 
         fig.tight_layout()
-        fig.savefig('runtimes.pdf', format='pdf')
+        fig.savefig('runtimes.pdf', type='pdf', bbox_extra_artists=(lgd,), bbox_inches='tight')

--- a/mdbenchmark/analyze.py
+++ b/mdbenchmark/analyze.py
@@ -33,6 +33,7 @@ from .utils import generate_output_name
 
 plt.switch_backend('agg')
 
+
 @cli.command()
 @click.option(
     '-d',

--- a/mdbenchmark/analyze.py
+++ b/mdbenchmark/analyze.py
@@ -31,6 +31,7 @@ from .mdengines import detect_md_engine, utils
 from .plot import plot_over_group
 from .utils import generate_output_name
 
+plt.switch_backend('agg')
 
 @cli.command()
 @click.option(

--- a/mdbenchmark/cli.py
+++ b/mdbenchmark/cli.py
@@ -35,5 +35,5 @@ class AliasedGroup(click.Group):
 @click.command(cls=AliasedGroup)
 @click.version_option()
 def cli():
-    """Generate, run and analyze benchmarks of GROMACS simulations."""
+    """Generate, run and analyze benchmarks of molecular dynamics simulations."""
     pass

--- a/mdbenchmark/plot.py
+++ b/mdbenchmark/plot.py
@@ -1,0 +1,94 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
+#
+# MDBenchmark
+# Copyright (c) 2017 Max Linke & Michael Gecht and contributors
+# (see the file AUTHORS for the full list of names)
+#
+# MDBenchmark is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# MDBenchmark is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MDBenchmark.  If not, see <http://www.gnu.org/licenses/>.
+import pandas as pd
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
+from matplotlib.figure import Figure
+import click
+
+from .cli import cli
+from .utils import calc_slope_intercept, lin_func
+
+
+def plot_line(df, label, ax=None):
+    if ax is None:
+        ax = plt.gca()
+
+    p = ax.plot('nodes', 'ns/day', '.-', data=df, ms='10', label=label)
+    color = p[0].get_color()
+    slope, intercept = calc_slope_intercept(
+        (df['nodes'].iloc[0], df['ns/day'].iloc[0]), (df['nodes'].iloc[1],
+                                                      df['ns/day'].iloc[1]))
+    # avoid a label and use values instead of pd.Series
+    ax.plot(
+        df['nodes'],
+        lin_func(df['nodes'].values, slope, intercept),
+        ls='--',
+        color=color,
+        alpha=.5)
+    return ax
+
+
+def plot_over_group(df, groupby, ax=None):
+    # plot all lines
+    gb = df.groupby(groupby)
+    for key, df in gb:
+        label = ' '.join(['{}={}'.format(n, v) for n, v in zip(groupby, key)])
+        plot_line(ax=ax, df=df, label=label)
+
+    # style axes
+    ax.set_xlabel('Number of nodes')
+    ax.set_ylabel('Performance [ns/day]')
+    ax.legend()
+
+    ax2 = ax.twiny()
+    ax1_xticks = ax.get_xticks()
+    ax2.set_xticks(ax1_xticks)
+    ax2.set_xbound(ax.get_xbound())
+    ax2.set_xticklabels(gb.get_group(list(gb.groups.keys())[0])['ncores'])
+    ax2.set_xlabel('{}'.format('{}\n\nCores'.format(df['host'][0])))
+
+    return ax
+
+
+@cli.command()
+@click.option('--csv', help='name of csv file')
+@click.option(
+    '--groupby',
+    '-g',
+    type=str,
+    help='columns to groupby for plot as comma separated string',
+    default='gpu, module',
+    show_default=True)
+def plot(csv, groupby):
+    """Plot nice things"""
+    df = pd.read_csv(csv, index_col=0)
+    # Remove NaN values. These are missing ncores/performance data.
+    df = df.dropna()
+    # We have to use the matplotlib object-oriented interface directly, because
+    # it expects a display to be attached to the system, which we don't on the
+    # clusters.
+    fig = Figure()
+    FigureCanvas(fig)
+    ax = fig.add_subplot(111)
+    # remove whitespace
+    groupby = [s.strip() for s in groupby.split(',')]
+    plot_over_group(df, groupby, ax=ax)
+    fig.savefig('results.pdf')

--- a/mdbenchmark/plot.py
+++ b/mdbenchmark/plot.py
@@ -83,6 +83,9 @@ def filter_dataframe_for_plotting(df, host_name, module_name, gpu, cpu):
     elif not cpu and not gpu:
         console.error("CPU and GPU not set. Nothing to plot. Exiting.")
 
+    if df.empty:
+        console.error("Your filtering led to an empty dataset. Exiting.")
+
     df_filtered_hosts = df[df['host'].isin(host_name)]
     df_unique_hosts = np.unique(df_filtered_hosts['host'])
 

--- a/mdbenchmark/plot.py
+++ b/mdbenchmark/plot.py
@@ -94,19 +94,21 @@ def filter_dataframe_for_plotting(df, host_name, module_name, gpu, cpu):
             ', '.join(np.unique(df['host']))))
 
     if not host_name:
-        console.info("Plotting all hosts in csv.")
+        console.info("Plotting all hosts in input file.")
     else:
         df = df_filtered_hosts
         console.info("Data for the following hosts will be plotted: {}".format(
             ', '.join(df_unique_hosts)))
 
     for module in module_name:
-        if module in ['gromacs', 'namd']:
-            console.info("Plotting all modules for engine {}.", module)
-        elif module in df['module'].tolist():
-            console.info("Plotting module {}.", module)
-        elif module not in df['module'].tolist():
-            console.error("The module {} does not exist in your data. Exiting.", module)
+        if module in ["gromacs", "namd"]:
+            console.info("Plotting all modules for engine '{}'.", module)
+        elif module in df["module"].tolist():
+            console.info("Plotting module '{}'.", module)
+        elif module not in df["module"].tolist():
+            console.error(
+                "The module '{}' does not exist in your data. Exiting.", module
+            )
 
     if not module_name:
         console.info("Plotting all modules in your input data.")
@@ -117,58 +119,50 @@ def filter_dataframe_for_plotting(df, host_name, module_name, gpu, cpu):
 
     if df.empty:
         console.error(
-            'Your selections contained no Benchmarking Information.\n'
-            'Are you sure all your selections are correct?')
+            "Your selections contained no benchmarking information. "
+            "Are you sure all your selections are correct?"
+        )
 
     return df
 
 
 @cli.command()
+@click.option("--csv", help="Name of CSV file to plot.", multiple=True)
+@click.option("--output-name", "-o", help="Name of output file.")
 @click.option(
-    '--csv',
-    help='Name of csv file to plot.',
-    multiple=True)
-@click.option(
-    '--output-name',
-    '-o',
-    help="Name of output file.")
-@click.option(
-    '--output-type',
-    '-t',
+    "--output-type",
+    "-t",
     help="File extension for output file.",
-    type=click.Choice(['png', 'pdf', 'svg', 'ps']),
+    type=click.Choice(["png", "pdf", "svg", "ps"]),
     show_default=True,
-    default='png')
+    default="png",
+)
 @click.option(
-    '--module-name',
-    '-h',
+    "--module-name",
+    "-h",
     multiple=True,
-    help="Module name or engine name (gromacs, namd) which is plotted.")
+    help="Name of the MD engine module(s) to plot.",
+)
+@click.option("--host-name", "-h", multiple=True, help="Name of hosts to plot.")
 @click.option(
-    '--host-name',
-    '-h',
-    multiple=True,
-    help="Host name which is plotted.")
+    "--gpu/--no-gpu", help="Plot data of GPU runs.", show_default=True, default=True
+)
 @click.option(
-    '--gpu/--no-gpu',
-    help="Plot data for GPU runs.",
-    show_default=True,
-    default=True)
+    "--cpu/--no-cpu", help="Plot data of CPU runs.", show_default=True, default=True
+)
 @click.option(
-    '--cpu/--no-cpu',
-    help="Plot data for CPU runs.",
-    show_default=True,
-    default=True)
-@click.option(
-    '--plot-cores',
+    "--plot-cores",
     help="Plot performance per core instead of nodes.",
     show_default=True,
-    is_flag=True)
+    is_flag=True,
+)
 def plot(csv, output_name, output_type, host_name, module_name, gpu, cpu, plot_cores):
     """Generate plots from csv files"""
 
     if not csv:
-        raise click.BadParameter('You must specify at least one csv file.', param_hint='"--csv"')
+        raise click.BadParameter(
+            "You must specify at least one CSV file.", param_hint='"--csv"'
+        )
 
     df = pd.concat([pd.read_csv(c, index_col=0) for c in csv]).dropna()
 
@@ -192,5 +186,4 @@ def plot(csv, output_name, output_type, host_name, module_name, gpu, cpu, plot_c
     # therefore i add it manually as extra artist. This way we don't get problems
     # with the variability of individual lines which are to be plotted
     fig.savefig(output_name, type=output_type, bbox_extra_artists=(lgd,), bbox_inches='tight')
-    console.info(
-        'Your file was saved as {} in the working directory.', output_name)
+    console.info("Your file was saved as '{}' in the working directory.", output_name)

--- a/mdbenchmark/plot.py
+++ b/mdbenchmark/plot.py
@@ -17,17 +17,18 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with MDBenchmark.  If not, see <http://www.gnu.org/licenses/>.
-import pandas as pd
-import numpy as np
+import click
 import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
 from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
 from matplotlib.figure import Figure
-import click
 
-from .cli import cli
-from .utils import calc_slope_intercept, lin_func, generate_output_name
 from . import console
+from .cli import cli
+from .utils import calc_slope_intercept, generate_output_name, lin_func
 
+plt.switch_backend('agg')
 
 def plot_line(df, selection, label, ax=None):
     if ax is None:

--- a/mdbenchmark/plot.py
+++ b/mdbenchmark/plot.py
@@ -30,6 +30,7 @@ from .utils import calc_slope_intercept, generate_output_name, lin_func
 
 plt.switch_backend('agg')
 
+
 def plot_line(df, selection, label, ax=None):
     if ax is None:
         ax = plt.gca()
@@ -37,8 +38,8 @@ def plot_line(df, selection, label, ax=None):
     p = ax.plot(selection, 'ns/day', '.-', data=df, ms='10', label=label)
     color = p[0].get_color()
     slope, intercept = calc_slope_intercept(
-        (df[selection].iloc[0], df['ns/day'].iloc[0]), (df[selection].iloc[1],
-                                                     df['ns/day'].iloc[1]))
+        (df[selection].iloc[0], df['ns/day'].iloc[0]),
+        (df[selection].iloc[1], df['ns/day'].iloc[1]))
     # avoid a label and use values instead of pd.Series
     ax.plot(
         df[selection],
@@ -81,7 +82,6 @@ def filter_dataframe_for_plotting(df, host_name, module_name, gpu, cpu):
         console.info("Plotting CPU data only.")
     elif not cpu and not gpu:
         console.error("CPU and GPU not set. Nothing to plot. Exiting.")
-
 
     for host in host_name:
         if host in df['host'].tolist():
@@ -163,9 +163,7 @@ def plot(csv, output_name, output_type, host_name, module_name, gpu, cpu, plot_c
     """Generate plots from csv files"""
 
     if not csv:
-        raise click.BadParameter(
-       'You must specify at least one csv file.',
-        param_hint='"--csv"')
+        raise click.BadParameter('You must specify at least one csv file.', param_hint='"--csv"')
 
     df = pd.concat([pd.read_csv(c, index_col=0) for c in csv]).dropna()
 

--- a/mdbenchmark/plot.py
+++ b/mdbenchmark/plot.py
@@ -83,17 +83,19 @@ def filter_dataframe_for_plotting(df, host_name, module_name, gpu, cpu):
     elif not cpu and not gpu:
         console.error("CPU and GPU not set. Nothing to plot. Exiting.")
 
-    for host in host_name:
-        if host in df['host'].tolist():
-            console.info('Data for the following hosts will be plotted: {}.', set(host_name))
-        elif host not in df['host'].tolist():
-            console.error('The host {} does not exist in your csv data. Exiting.', host)
+    df_filtered_hosts = df[df['host'].isin(host_name)]
+    df_unique_hosts = np.unique(df_filtered_hosts['host'])
+
+    if df_unique_hosts.size != len(host_name):
+        console.error("Could not find all provided hosts. Available hosts are: {}".format(
+            ', '.join(np.unique(df['host']))))
 
     if not host_name:
         console.info("Plotting all hosts in csv.")
-
-    if host_name:
-        df = df[df['host'].str.contains('|'.join(host_name))]
+    else:
+        df = df_filtered_hosts
+        console.info("Data for the following hosts will be plotted: {}".format(
+            ', '.join(df_unique_hosts)))
 
     for module in module_name:
         if module in ['gromacs', 'namd']:

--- a/mdbenchmark/plot.py
+++ b/mdbenchmark/plot.py
@@ -24,71 +24,157 @@ from matplotlib.figure import Figure
 import click
 
 from .cli import cli
-from .utils import calc_slope_intercept, lin_func
+from .utils import calc_slope_intercept, lin_func, generate_output_name
+from . import console
 
 
-def plot_line(df, label, ax=None):
+def plot_line(df, df_sel, label, ax=None):
     if ax is None:
         ax = plt.gca()
 
-    p = ax.plot('nodes', 'ns/day', '.-', data=df, ms='10', label=label)
+    p = ax.plot(df_sel, 'ns/day', '.-', data=df, ms='10', label=label)
     color = p[0].get_color()
     slope, intercept = calc_slope_intercept(
-        (df['nodes'].iloc[0], df['ns/day'].iloc[0]), (df['nodes'].iloc[1],
-                                                      df['ns/day'].iloc[1]))
+        (df[df_sel].iloc[0], df['ns/day'].iloc[0]), (df[df_sel].iloc[1],
+                                                     df['ns/day'].iloc[1]))
     # avoid a label and use values instead of pd.Series
     ax.plot(
-        df['nodes'],
-        lin_func(df['nodes'].values, slope, intercept),
+        df[df_sel],
+        lin_func(df[df_sel].values, slope, intercept),
         ls='--',
         color=color,
         alpha=.5)
     return ax
 
 
-def plot_over_group(df, groupby, ax=None):
+def plot_over_group(df, plot_cores, ax=None):
     # plot all lines
-    gb = df.groupby(groupby)
+    df_sel = 'ncores' if plot_cores else 'nodes'
+
+    gb = df.groupby(['gpu', 'module', 'host'])
+    groupby = ['gpu', 'module', 'host']
     for key, df in gb:
         label = ' '.join(['{}={}'.format(n, v) for n, v in zip(groupby, key)])
-        plot_line(ax=ax, df=df, label=label)
+        plot_line(df=df, df_sel=df_sel, ax=ax, label=label)
 
     # style axes
-    ax.set_xlabel('Number of nodes')
+    xlabel = 'cores' if plot_cores else 'nodes'
+    ax.set_xlabel('Number of {}'.format(xlabel))
     ax.set_ylabel('Performance [ns/day]')
     ax.legend()
-
-    ax2 = ax.twiny()
-    ax1_xticks = ax.get_xticks()
-    ax2.set_xticks(ax1_xticks)
-    ax2.set_xbound(ax.get_xbound())
-    ax2.set_xticklabels(gb.get_group(list(gb.groups.keys())[0])['ncores'])
-    ax2.set_xlabel('{}'.format('{}\n\nCores'.format(df['host'][0])))
 
     return ax
 
 
+def filter_dataframe_for_plotting(df, host_name, module_name, gpu, cpu):
+    # gpu/cpu can be plotted together or separately
+    if gpu and cpu:
+        # if no flags are given by the user or both are set everything is plotted
+        console.info("plotting GPU and CPU data.")
+    elif gpu and not cpu:
+        df = df[df.gpu]
+        console.info("plotting GPU data only.")
+    elif cpu and not gpu:
+        df = df[~df.gpu]
+        console.info("plotting CPU data only.")
+    elif not cpu and not gpu:
+        console.error("CPU and GPU not set. Nothing to plot. Exiting")
+
+    for host in host_name:
+        if host in df['host'].tolist():
+            df = df[df['host'].isin(host_name)]
+            console.info('Data for the following hosts will be plotted: {}.', set(host_name))
+        elif not host:
+            # dataframe stays the same and all hosts will be plotted
+            console.info('All hosts will be plotted.')
+        elif host not in df['host'].tolist():
+            # filter host names that don't exist
+            console.error('The host {} does not exist in your csv data. Exiting.', host)
+
+    if not host_name:
+        console.info("plotting all hosts in csv.")
+
+    for module in module_name:
+        if module in ['gromacs', 'namd']:
+            console.info("plotting all modules for engine {}.", module)
+        elif module not in df['module'].tolist():
+            console.error("The module {} does not exist in your data. Exiting.", module)
+
+    if not module_name:
+        console.info("plotting all modules in your input data.")
+    # this should work but we need to check before whether any of the entered
+    # names are faulty/don't exist
+    if module_name:
+        df = df[df['module'].str.contains('|'.join(module_name))]
+
+    if df.empty:
+        console.error(
+            'Your selections contained no Benchmarking Information.\n'
+            'Are you sure all your selections are correct?')
+
+    return df
+
+
 @cli.command()
-@click.option('--csv', help='name of csv file')
 @click.option(
-    '--groupby',
-    '-g',
-    type=str,
-    help='columns to groupby for plot as comma separated string',
-    default='gpu, module',
-    show_default=True)
-def plot(csv, groupby):
-    """Plot nice things"""
-    df = pd.read_csv(csv, index_col=0)
-    # Remove NaN values. These are missing ncores/performance data.
-    df = df.dropna()
-    # We have to use the matplotlib object-oriented interface directly, because
-    # it expects a display to be attached to the system, which we don't on the
-    # clusters.
+    '--csv',
+    help='Name of csv file to plot.',
+    multiple=True)
+@click.option(
+    '--output-name',
+    '-o',
+    help="Name of output file.")
+@click.option(
+    '--output-type',
+    '-t',
+    help="File extension for output file.",
+    type=click.Choice(['png', 'pdf', 'svg', 'ps']),
+    show_default=True,
+    default='png')
+@click.option(
+    '--module-name',
+    '-h',
+    multiple=True,
+    help="Module name or engine name (gromacs, namd) which is plotted.")
+@click.option(
+    '--host-name',
+    '-h',
+    multiple=True,
+    help="Host name which is plotted.")
+@click.option(
+    '--gpu/--no-gpu',
+    help="Plot data for GPU runs.",
+    show_default=True,
+    default=True)
+@click.option(
+    '--cpu/--no-cpu',
+    help="Plot data for CPU runs.",
+    show_default=True,
+    default=True)
+@click.option(
+    '--plot-cores',
+    help="Plot performance per core instead of nodes",
+    show_default=True,
+    is_flag=True)
+def plot(csv, output_name, output_type, host_name, module_name, gpu, cpu, plot_cores):
+    """Generate plots from csv files"""
+    print(host_name)
+    if not csv:
+        console.error("No csv file specified. use --csv to specify a file.")
+
+    df = pd.concat([pd.read_csv(c, index_col=0) for c in csv]).dropna()
+
+    df = filter_dataframe_for_plotting(df, host_name, module_name, gpu, cpu)
+
     fig = Figure()
     FigureCanvas(fig)
     ax = fig.add_subplot(111)
-    # remove whitespace
-    groupby = [s.strip() for s in groupby.split(',')]
-    plot_over_group(df, groupby, ax=ax)
-    fig.savefig('results.pdf')
+    plot_over_group(df, plot_cores, ax=ax)
+
+    if output_name is None:
+        output_name = generate_output_name(output_type)
+    elif output_name.endswith('.{}'.format(output_type)):
+        output_name = '{}.{}'.format(output_name, output_type)
+    fig.savefig(output_name, type=output_type)
+    console.info(
+        'Your file was saved as {} in the working directory.', output_name)

--- a/mdbenchmark/tests/data/runtime2.csv
+++ b/mdbenchmark/tests/data/runtime2.csv
@@ -1,0 +1,8 @@
+,module,nodes,ns/day,run time [min],gpu,host,ncores
+0,gromacs/2016.4,1,98.147,15,True,draco,32
+1,gromacs/2016.4,2,178.044,15,True,draco,64
+2,gromacs/2016.4,3,226.108,15,True,draco,96
+3,gromacs/2016.4,4,246.973,15,True,draco,128
+4,gromacs/2016.4,5,254.266,15,True,draco,160
+5,namd,1,0.07632830329814598,15,False,hydra,1
+6,namd,2,0.07632830329814598,15,False,hydra,1

--- a/mdbenchmark/tests/data/test.csv
+++ b/mdbenchmark/tests/data/test.csv
@@ -1,0 +1,15 @@
+,module,nodes,ns/day,run time [min],gpu,host,ncores
+0,gromacs/2016.3,1,50,15,False,draco,32
+1,gromacs/2016.3,2,80,15,False,draco,64
+2,gromacs/2016.3,3,100,15,False,draco,96
+3,gromacs/2016.3,4,110,15,False,draco,128
+4,gromacs/2016.3,5,130,15,False,draco,160
+5,namd/2.12,1,30,15,True,draco,1
+6,namd/2.12,2,70,15,True,draco,1
+0,gromacs/2018,1,98.147,15,True,draco,32
+1,gromacs/2018,2,178.044,15,True,draco,64
+2,gromacs/2018,3,226.108,15,True,draco,96
+3,gromacs/2018,4,246.97299999999998,15,True,draco,128
+4,gromacs/2018,5,254.266,15,True,draco,160
+5,namd/2.9,1,20,15,False,hydra,1
+6,namd/2.9,2,45,15,False,hydra,1

--- a/mdbenchmark/tests/data/testcsv.csv
+++ b/mdbenchmark/tests/data/testcsv.csv
@@ -1,0 +1,14 @@
+,module,nodes,ns/day,run time [min],gpu,host,ncores
+0,gromacs/2016.4-plumed2.3,1,99.102,15,True,hydra,24
+1,gromacs/2016.4-plumed2.3,2,161.454,15,True,hydra,48
+2,gromacs/2016.4-plumed2.3,3,174.379,15,True,hydra,72
+3,gromacs/2016.4-plumed2.3,4,181.614,15,True,hydra,96
+4,gromacs/5.1.4-plumed2.3,2,87.189,15,False,hydra,48
+5,gromacs/5.1.4-plumed2.3,3,127.573,15,False,hydra,72
+6,gromacs/5.1.4-plumed2.3,4,159.016,15,False,hydra,96
+7,gromacs/5.1.4-plumed2.3,1,97.981,15,False,hydra,24
+8,namd/2.12,2,125.945,15,False,draco,48
+9,namd/2.12,3,153.656,15,False,draco,72
+10,namd/2.12,4,143.268,15,True,draco,96
+11,namd/2.12,5,157.94,15,True,draco,120
+12,namd/2.12,6,200,15,True,draco,144

--- a/mdbenchmark/tests/test_plot.py
+++ b/mdbenchmark/tests/test_plot.py
@@ -1,0 +1,234 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
+#
+# MDBenchmark
+# Copyright (c) 2017 Max Linke & Michael Gecht and contributors
+# (see the file AUTHORS for the full list of names)
+#
+# MDBenchmark is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# MDBenchmark is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MDBenchmark.  If not, see <http://www.gnu.org/licenses/>.
+import click
+import numpy as np
+import pytest
+import os
+import pandas as pd
+from numpy.testing import assert_equal
+from pandas.testing import assert_frame_equal
+
+from mdbenchmark import utils
+from mdbenchmark import cli
+from mdbenchmark import plot
+from mdbenchmark.testing import data
+from mdbenchmark.ext.click_test import cli_runner
+
+
+# @pytest.mark.parametrize('module_selection', 'host', [
+#     ('gromacs/2018', 'draco'),
+#     ('namd/2.12', 'draco'),
+#     ('gromacs/2016.3', 'hydra')
+# ])
+# def test_plot_filtering_success(cli_runner, tmpdir, data module_selection, expected_df, host):
+#     """Test whether we can plot over different groups.
+#     """
+#     with tmpdir.as_cwd():
+#
+#         output = 'The following modules will be plotted {{'{}'}}.\n'.format{module_selection} \
+#                  'Your file was saved as testpng.png in the working directory.''
+#
+#         result = cli_runner.invoke(cli.cli, [
+#             'plot',
+#             '--csv=test.csv', '--module-name={}'.format(module_selection),
+#             '--host-name={}'.format(host), '--output-name=testpng'
+#         ])
+#         assert result.exit_code == 0
+#         assert result.output == output
+#         assert os.path.exists("testpng.png")
+
+# @pytest.mark.parametrize('module_selection', 'host', [
+#     ('gromacs/2018', 'failengine'),
+#     ('failengine', 'draco')
+# ])
+# def test_plot_filtering_fail(cli_runner, tmpdir, data, module_selection, host):
+#     """Test unsuccessful filtering and error message.
+#     """
+#     with tmpdir.as_cwd():
+#
+#         output = ''
+#
+#         result = cli_runner.invoke(cli.cli, [
+#             'plot',
+#             '--csv={}'.format(data['test.csv']), '--module-name={}'.format(module_selection),
+#             '--host-name={}'.format(host), '--output-name=testpng'
+#         ])
+#
+#         assert result.output == output
+#         assert result.exit_code == 1
+
+
+def test_plot_gpu(cli_runner, tmpdir, data):
+    """Test gpu flage without any host or module.
+    """
+    with tmpdir.as_cwd():
+        output = 'All modules will be plotted.\n' \
+                 'All hosts will be plotted.\n' \
+                 'A total of 4 runs will be plotted.\n' \
+                 'Your file was saved as testpng.png in the working directory.\n' \
+
+        result = cli_runner.invoke(cli.cli, [
+            'plot',
+            '--csv={}'.format(data['test.csv']), '--gpu', '--output-name=testpng.png'
+        ])
+
+        assert result.exit_code == 0
+        assert result.output == output
+        assert os.path.exists("testpng.png")
+
+
+@pytest.mark.parametrize('host', ('draco', 'hydra'))
+def test_plot_host_only(cli_runner, tmpdir, host, data):
+    """Test only giving a host.
+    """
+    with tmpdir.as_cwd():
+
+        output = 'All modules will be plotted.\n' \
+                 'Data for the following hosts will be plotted: {{\'{}\'}}.\n'\
+                 'A total of 1 runs will be plotted.\n' \
+                 'Your file was saved as testpng.png in the working directory.\n'.format(host)
+
+        result = cli_runner.invoke(cli.cli, [
+            'plot',
+            '--csv={}'.format(data['test.csv']), '--host-name={}'.format(host),
+            '--output-name=testpng.png'
+        ])
+
+        assert result.exit_code == 0
+        assert result.output == output
+        assert os.path.exists("testpng.png")
+
+
+# @pytest.mark.parametrize('module', ('gromacs', 'namd', 'namd/2.12', 'gromacs/2018'))
+# def test_plot_module_only(cli_runner, tmpdir, module):
+#     """Test only giving a module.
+#     """
+#     with tmpdir.as_cwd():
+#
+#         output = ''
+#
+#         result = cli_runner.invoke(cli.cli, [
+#             'plot',
+#             '--csv=test.csv', '--module-name={}'.format(module_selection),
+#             '--host-name={}'.format(host), '--output-name=testpng'
+#         ])
+#
+#
+@pytest.mark.parametrize('output_type', ('png', 'pdf'))
+def test_plot_output_type(cli_runner, tmpdir, data, output_type):
+    """check whether output types are constructed correctly
+    """
+    with tmpdir.as_cwd():
+
+        output = 'All modules will be plotted.\n' \
+                 'All hosts will be plotted.\n' \
+                 'A total of 2 runs will be plotted.\n' \
+                 'Your file was saved as test.{} in the working directory.\n'.format(output_type)
+
+        result = cli_runner.invoke(cli.cli, [
+            'plot',
+            '--csv={}'.format(data['test.csv']), '--output-name=testfile', '--output-type={}'.format(output_type)
+        ])
+        assert result.exit_code == 0
+        assert os.path.exists("testfile.{}".format(output_type))
+
+
+@pytest.mark.parametrize("gpu,cpu", [
+    (True, True),
+    (True, False),
+    (False, True),
+])
+def test_plot_filter_dataframe_for_plotting_gpu_and_cpu(cli_runner, tmpdir, data, gpu, cpu):
+    """ check whether output types are constructed correctly
+    """
+    with tmpdir.as_cwd():
+
+        input_df = pd.read_csv(data['testcsv.csv'])
+
+        test_df = input_df
+
+        if gpu and not cpu:
+            input_df = input_df[input_df.gpu]
+        elif not gpu and cpu:
+            input_df = input_df[~input_df.gpu]
+        elif not gpu and not cpu:
+            input_df = pd.read_csv(data['empty_df.csv'])
+
+        real_df = plot.filter_dataframe_for_plotting(df=input_df, host_name=(), module_name=(), gpu=gpu, cpu=cpu)
+
+        # here we compare the dataframes for any differences
+        assert_frame_equal(input_df, real_df)
+
+
+@pytest.mark.parametrize("gpu,cpu", [
+    (False, False)
+])
+def test_plot_filter_dataframe_for_plotting_gpu_and_cpu_fail(capsys, cli_runner, tmpdir, data, gpu, cpu):
+    """ check whether output types are constructed correctly
+    """
+    with tmpdir.as_cwd():
+        input_df = pd.read_csv(data['testcsv.csv'])
+
+        expected_output = "CPU and GPU not set. Nothing to plot. Exiting."
+        plot.filter_dataframe_for_plotting(df=input_df, host_name=(), module_name=(), gpu=gpu, cpu=cpu)
+        out, err = capsys.readouterr()
+        assert out == expected_output
+
+@pytest.mark.parametrize('module_name', [
+    ('namd/2.12'),
+    ('gromacs/5.1.4-plumed2.3'),
+    ('gromacs'),
+    ('namd')
+])
+def test_plot_filter_dataframe_for_plotting_module_name(cli_runner, tmpdir, data, module_name):
+    """ check whether output types are constructed correctly
+    """
+    with tmpdir.as_cwd():
+
+        expected_df = pd.read_csv(data['testcsv.csv'])
+        expected_df = expected_df[expected_df['module'].str.contains(module_name)]
+
+        input_df = pd.read_csv(data['testcsv.csv'])
+
+        module = (module_name,)
+        real_df = plot.filter_dataframe_for_plotting(df=input_df, host_name=(), module_name=module, gpu=True, cpu=True)
+
+        assert_frame_equal(expected_df, real_df)
+
+
+@pytest.mark.parametrize("host_name", [
+    ('hydra'),
+    ('draco')
+])
+def test_plot_filter_dataframe_for_plotting_host_name(cli_runner, tmpdir, data, host_name):
+    """ check whether output types are constructed correctly
+    """
+    with tmpdir.as_cwd():
+
+        expected_df = pd.read_csv(data['testcsv.csv'])
+        expected_df = expected_df[expected_df['host'].str.contains(host_name)]
+
+        input_df = pd.read_csv(data['testcsv.csv'])
+
+        # I have to convert the variable to a tuple, otherwise this appears not to work
+        host = (host_name,)
+        real_df = plot.filter_dataframe_for_plotting(df=input_df, host_name=host, module_name=(), gpu=True, cpu=True)
+
+        assert_frame_equal(expected_df, real_df)

--- a/mdbenchmark/tests/test_plot.py
+++ b/mdbenchmark/tests/test_plot.py
@@ -22,10 +22,10 @@ import os
 import click
 import numpy as np
 import pandas as pd
-import pytest
 from numpy.testing import assert_equal
 from pandas.testing import assert_frame_equal
 
+import pytest
 from mdbenchmark import cli, plot, utils
 from mdbenchmark.ext.click_test import cli_runner
 from mdbenchmark.testing import data
@@ -36,111 +36,144 @@ def test_plot_gpu(cli_runner, tmpdir, data):
     """
     with tmpdir.as_cwd():
 
-        output = 'Plotting GPU and CPU data.\n' \
-                 'Plotting all hosts in csv.\n' \
-                 'Plotting all modules in your input data.\n' \
-                 'Your file was saved as testpng.png in the working directory.\n'
+        output = (
+            "Plotting GPU and CPU data.\n"
+            "Plotting all hosts in input file.\n"
+            "Plotting all modules in your input data.\n"
+            "Your file was saved as 'testpng.png' in the working directory.\n"
+        )
 
-        result = cli_runner.invoke(cli.cli, [
-            'plot',
-            '--csv={}'.format(data['test.csv']),
-            '--gpu',
-            '--output-name=testpng',
-            '--output-type=png'
-        ])
+        result = cli_runner.invoke(
+            cli.cli,
+            [
+                "plot",
+                "--csv={}".format(data["test.csv"]),
+                "--gpu",
+                "--output-name=testpng",
+                "--output-type=png",
+            ],
+        )
 
         assert result.exit_code == 0
         assert result.output == output
         assert os.path.exists("testpng.png")
 
 
-@pytest.mark.parametrize('host', ('draco', 'hydra'))
+@pytest.mark.parametrize("host", ("draco", "hydra"))
 def test_plot_host_only(cli_runner, tmpdir, host, data):
     """Test plotting function with one given host.
     """
     with tmpdir.as_cwd():
 
-        output = 'Plotting GPU and CPU data.\n' \
-                 'Data for the following hosts will be plotted: {}\n' \
-                 'Plotting all modules in your input data.\n' \
-                 'Your file was saved as testpng.png in the working directory.\n'.format(host)
+        output = (
+            "Plotting GPU and CPU data.\n"
+            "Data for the following hosts will be plotted: {}\n"
+            "Plotting all modules in your input data.\n"
+            "Your file was saved as 'testpng.png' in the working directory.\n".format(
+                host
+            )
+        )
 
-        result = cli_runner.invoke(cli.cli, [
-            'plot',
-            '--csv={}'.format(data['test.csv']), '--host-name={}'.format(host),
-            '--output-name=testpng', '--output-type=png'
-        ])
+        result = cli_runner.invoke(
+            cli.cli,
+            [
+                "plot",
+                "--csv={}".format(data["test.csv"]),
+                "--host-name={}".format(host),
+                "--output-name=testpng",
+                "--output-type=png",
+            ],
+        )
 
         assert result.exit_code == 0
         assert result.output == output
         assert os.path.exists("testpng.png")
 
 
-@pytest.mark.parametrize('module', ('gromacs', 'namd', 'namd/2.12', 'gromacs/2018'))
+@pytest.mark.parametrize("module", ("gromacs", "namd", "namd/2.12", "gromacs/2018"))
 def test_plot_module_only(cli_runner, tmpdir, module, data):
     """Test plotting function with one given engine or module.
     """
     with tmpdir.as_cwd():
-        if module in ['gromacs', 'namd']:
-            output = 'Plotting GPU and CPU data.\n' \
-                     'Plotting all hosts in csv.\n' \
-                     'Plotting all modules for engine {}.\n' \
-                     'Your file was saved as testpng.png in the working directory.\n'.format(module)
+        if module in ["gromacs", "namd"]:
+            output = (
+                "Plotting GPU and CPU data.\n"
+                "Plotting all hosts in input file.\n"
+                "Plotting all modules for engine '{}'.\n"
+                "Your file was saved as 'testpng.png' in the working directory.\n".format(
+                    module
+                )
+            )
         else:
-            output = 'Plotting GPU and CPU data.\n' \
-                     'Plotting all hosts in csv.\n' \
-                     'Plotting module {}.\n' \
-                     'Your file was saved as testpng.png in the working directory.\n'.format(module)
+            output = (
+                "Plotting GPU and CPU data.\n"
+                "Plotting all hosts in input file.\n"
+                "Plotting module '{}'.\n"
+                "Your file was saved as 'testpng.png' in the working directory.\n".format(
+                    module
+                )
+            )
 
-        result = cli_runner.invoke(cli.cli, [
-            'plot',
-            '--csv={}'.format(data['test.csv']), '--module-name={}'.format(module),
-            '--output-name=testpng'
-        ])
+        result = cli_runner.invoke(
+            cli.cli,
+            [
+                "plot",
+                "--csv={}".format(data["test.csv"]),
+                "--module-name={}".format(module),
+                "--output-name=testpng",
+            ],
+        )
 
         assert result.exit_code == 0
         assert result.output == output
         assert os.path.exists("testpng.png")
 
 
-@pytest.mark.parametrize('output_type', ('png', 'pdf'))
+@pytest.mark.parametrize("output_type", ("png", "pdf"))
 def test_plot_output_type(cli_runner, tmpdir, data, output_type):
     """check whether output types are constructed correctly.
     """
     with tmpdir.as_cwd():
 
-        output = 'All modules will be plotted.\n' \
-                 'All hosts will be plotted.\n' \
-                 'A total of 2 runs will be plotted.\n' \
-                 'Your file was saved as test.{} in the working directory.\n'.format(output_type)
+        output = (
+            "All modules will be plotted.\n"
+            "All hosts will be plotted.\n"
+            "A total of 2 runs will be plotted.\n"
+            "Your file was saved as 'test.{}' in the working directory.\n".format(
+                output_type
+            )
+        )
 
-        output = 'Plotting GPU and CPU data.\n' \
-                 'Plotting all hosts in csv.\n' \
-                 'Plotting all modules in your input data.\n' \
-                 'Your file was saved as testfile.{} in the working ' \
-                 'directory.\n'.format(output_type)
-        result = cli_runner.invoke(cli.cli, [
-            'plot',
-            '--csv={}'.format(data['test.csv']),
-            '--output-name=testfile',
-            '--output-type={}'.format(output_type)
-        ])
+        output = (
+            "Plotting GPU and CPU data.\n"
+            "Plotting all hosts in input file.\n"
+            "Plotting all modules in your input data.\n"
+            "Your file was saved as 'testfile.{}' in the working "
+            "directory.\n".format(output_type)
+        )
+        result = cli_runner.invoke(
+            cli.cli,
+            [
+                "plot",
+                "--csv={}".format(data["test.csv"]),
+                "--output-name=testfile",
+                "--output-type={}".format(output_type),
+            ],
+        )
         assert result.output == output
         assert result.exit_code == 0
         # assert os.path.exists("testfile.{}".format(output_type))
 
 
-@pytest.mark.parametrize("gpu,cpu", [
-    (True, True),
-    (True, False),
-    (False, True),
-])
-def test_plot_filter_dataframe_for_plotting_gpu_and_cpu(cli_runner, tmpdir, data, gpu, cpu):
+@pytest.mark.parametrize("gpu,cpu", [(True, True), (True, False), (False, True)])
+def test_plot_filter_dataframe_for_plotting_gpu_and_cpu(
+    cli_runner, tmpdir, data, gpu, cpu
+):
     """ Checks whether the cpu and gpu filtering works properly.
     """
     with tmpdir.as_cwd():
 
-        input_df = pd.read_csv(data['testcsv.csv'])
+        input_df = pd.read_csv(data["testcsv.csv"])
 
         test_df = input_df
 
@@ -149,81 +182,73 @@ def test_plot_filter_dataframe_for_plotting_gpu_and_cpu(cli_runner, tmpdir, data
         elif not gpu and cpu:
             input_df = input_df[~input_df.gpu]
         elif not gpu and not cpu:
-            input_df = pd.read_csv(data['empty_df.csv'])
+            input_df = pd.read_csv(data["empty_df.csv"])
 
-        real_df = plot.filter_dataframe_for_plotting(df=input_df,
-                                                     host_name=(),
-                                                     module_name=(),
-                                                     gpu=gpu,
-                                                     cpu=cpu)
+        real_df = plot.filter_dataframe_for_plotting(
+            df=input_df, host_name=(), module_name=(), gpu=gpu, cpu=cpu
+        )
 
         # here we compare the dataframes for any differences
         assert_frame_equal(input_df, real_df)
 
 
-def test_plot_filter_dataframe_for_plotting_gpu_and_cpu_fail(capsys, cli_runner, tmpdir, data):
+def test_plot_filter_dataframe_for_plotting_gpu_and_cpu_fail(
+    capsys, cli_runner, tmpdir, data
+):
     """ Tests the error when gpu and cpu are set to false.
     """
     with tmpdir.as_cwd():
-        input_df = pd.read_csv(data['testcsv.csv'])
+        input_df = pd.read_csv(data["testcsv.csv"])
 
         expected_output = "ERROR CPU and GPU not set. Nothing to plot. Exiting.\n"
         with pytest.raises(SystemExit) as error:
-            plot.filter_dataframe_for_plotting(df=input_df,
-                                               host_name=(),
-                                               module_name=(),
-                                               gpu=False,
-                                               cpu=False)
+            plot.filter_dataframe_for_plotting(
+                df=input_df, host_name=(), module_name=(), gpu=False, cpu=False
+            )
         out, err = capsys.readouterr()
         assert out == expected_output
         assert error.type == SystemExit
         assert error.value.code == 1
 
 
-@pytest.mark.parametrize('module_name', [
-    ('namd/2.12'),
-    ('gromacs/5.1.4-plumed2.3'),
-    ('gromacs'),
-    ('namd')
-])
-def test_plot_filter_dataframe_for_plotting_module_name(cli_runner, tmpdir, data, module_name):
+@pytest.mark.parametrize(
+    "module_name", [("namd/2.12"), ("gromacs/5.1.4-plumed2.3"), ("gromacs"), ("namd")]
+)
+def test_plot_filter_dataframe_for_plotting_module_name(
+    cli_runner, tmpdir, data, module_name
+):
     """ Checks whether the module names are filterd correctly in the filtering function.
     """
     with tmpdir.as_cwd():
 
-        expected_df = pd.read_csv(data['testcsv.csv'])
-        expected_df = expected_df[expected_df['module'].str.contains(module_name)]
+        expected_df = pd.read_csv(data["testcsv.csv"])
+        expected_df = expected_df[expected_df["module"].str.contains(module_name)]
 
-        input_df = pd.read_csv(data['testcsv.csv'])
+        input_df = pd.read_csv(data["testcsv.csv"])
 
         module = (module_name,)
-        real_df = plot.filter_dataframe_for_plotting(df=input_df,
-                                                     host_name=(),
-                                                     module_name=module,
-                                                     gpu=True,
-                                                     cpu=True)
+        real_df = plot.filter_dataframe_for_plotting(
+            df=input_df, host_name=(), module_name=module, gpu=True, cpu=True
+        )
 
         assert_frame_equal(expected_df, real_df)
 
 
-@pytest.mark.parametrize("host_name", [
-    ('hydra'),
-    ('draco')
-])
-def test_plot_filter_dataframe_for_plotting_host_name(cli_runner, tmpdir, data, host_name):
+@pytest.mark.parametrize("host_name", [("hydra"), ("draco")])
+def test_plot_filter_dataframe_for_plotting_host_name(
+    cli_runner, tmpdir, data, host_name
+):
     """ Checks whether the host names are filtered correctly in the filtering function.
     """
     with tmpdir.as_cwd():
-        expected_df = pd.read_csv(data['testcsv.csv'])
-        expected_df = expected_df[expected_df['host'].str.contains(host_name)]
+        expected_df = pd.read_csv(data["testcsv.csv"])
+        expected_df = expected_df[expected_df["host"].str.contains(host_name)]
 
-        input_df = pd.read_csv(data['testcsv.csv'])
+        input_df = pd.read_csv(data["testcsv.csv"])
 
-        real_df = plot.filter_dataframe_for_plotting(df=input_df,
-                                                     host_name=(host_name,),
-                                                     module_name=(),
-                                                     gpu=True,
-                                                     cpu=True)
+        real_df = plot.filter_dataframe_for_plotting(
+            df=input_df, host_name=(host_name,), module_name=(), gpu=True, cpu=True
+        )
 
         assert_frame_equal(expected_df, real_df)
 
@@ -232,18 +257,18 @@ def test_plot_filter_empty_dataframe_error(cli_runner, capsys, tmpdir, data):
     """Assert that we exit when given an empty DataFrame through a specific filter combination.
     """
     with tmpdir.as_cwd():
-        df = pd.read_csv(data['testcsv.csv'])
-        df = df[(~df['gpu']) & (df['host'] == 'draco')]
+        df = pd.read_csv(data["testcsv.csv"])
+        df = df[(~df["gpu"]) & (df["host"] == "draco")]
 
         with pytest.raises(SystemExit) as error:
-            real_df = plot.filter_dataframe_for_plotting(df=df,
-                                                         host_name=('draco',),
-                                                         module_name=(),
-                                                         gpu=True,
-                                                         cpu=False)
+            real_df = plot.filter_dataframe_for_plotting(
+                df=df, host_name=("draco",), module_name=(), gpu=True, cpu=False
+            )
 
-        expected_output = ("Plotting GPU data only.\n"
-                           "ERROR Your filtering led to an empty dataset. Exiting.\n")
+        expected_output = (
+            "Plotting GPU data only.\n"
+            "ERROR Your filtering led to an empty dataset. Exiting.\n"
+        )
         out, err = capsys.readouterr()
         assert out == expected_output
         assert error.type == SystemExit

--- a/mdbenchmark/tests/test_plot.py
+++ b/mdbenchmark/tests/test_plot.py
@@ -17,19 +17,18 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with MDBenchmark.  If not, see <http://www.gnu.org/licenses/>.
+import os
+
 import click
 import numpy as np
-import pytest
-import os
 import pandas as pd
 from numpy.testing import assert_equal
 from pandas.testing import assert_frame_equal
 
-from mdbenchmark import utils
-from mdbenchmark import cli
-from mdbenchmark import plot
-from mdbenchmark.testing import data
+import pytest
+from mdbenchmark import cli, plot, utils
 from mdbenchmark.ext.click_test import cli_runner
+from mdbenchmark.testing import data
 
 
 def test_plot_gpu(cli_runner, tmpdir, data):
@@ -44,7 +43,10 @@ def test_plot_gpu(cli_runner, tmpdir, data):
 
         result = cli_runner.invoke(cli.cli, [
             'plot',
-            '--csv={}'.format(data['test.csv']), '--gpu', '--output-name=testpng', '--output-type=png'
+            '--csv={}'.format(data['test.csv']),
+            '--gpu',
+            '--output-name=testpng',
+            '--output-type=png'
         ])
 
         assert result.exit_code == 0
@@ -101,7 +103,6 @@ def test_plot_module_only(cli_runner, tmpdir, module, data):
         assert os.path.exists("testpng.png")
 
 
-
 @pytest.mark.parametrize('output_type', ('png', 'pdf'))
 def test_plot_output_type(cli_runner, tmpdir, data, output_type):
     """check whether output types are constructed correctly.
@@ -116,14 +117,17 @@ def test_plot_output_type(cli_runner, tmpdir, data, output_type):
         output = 'Plotting GPU and CPU data.\n' \
                  'Plotting all hosts in csv.\n' \
                  'Plotting all modules in your input data.\n' \
-                 'Your file was saved as testfile.{} in the working directory.\n'.format(output_type)
+                 'Your file was saved as testfile.{} in the working ' \
+                 'directory.\n'.format(output_type)
         result = cli_runner.invoke(cli.cli, [
             'plot',
-            '--csv={}'.format(data['test.csv']), '--output-name=testfile', '--output-type={}'.format(output_type)
+            '--csv={}'.format(data['test.csv']),
+            '--output-name=testfile',
+            '--output-type={}'.format(output_type)
         ])
         assert result.output == output
         assert result.exit_code == 0
-        #assert os.path.exists("testfile.{}".format(output_type))
+        # assert os.path.exists("testfile.{}".format(output_type))
 
 
 @pytest.mark.parametrize("gpu,cpu", [
@@ -147,7 +151,11 @@ def test_plot_filter_dataframe_for_plotting_gpu_and_cpu(cli_runner, tmpdir, data
         elif not gpu and not cpu:
             input_df = pd.read_csv(data['empty_df.csv'])
 
-        real_df = plot.filter_dataframe_for_plotting(df=input_df, host_name=(), module_name=(), gpu=gpu, cpu=cpu)
+        real_df = plot.filter_dataframe_for_plotting(df=input_df,
+                                                     host_name=(),
+                                                     module_name=(),
+                                                     gpu=gpu,
+                                                     cpu=cpu)
 
         # here we compare the dataframes for any differences
         assert_frame_equal(input_df, real_df)
@@ -161,7 +169,11 @@ def test_plot_filter_dataframe_for_plotting_gpu_and_cpu_fail(capsys, cli_runner,
 
         expected_output = "ERROR CPU and GPU not set. Nothing to plot. Exiting.\n"
         with pytest.raises(SystemExit) as error:
-            plot.filter_dataframe_for_plotting(df=input_df, host_name=(), module_name=(), gpu=False, cpu=False)
+            plot.filter_dataframe_for_plotting(df=input_df,
+                                               host_name=(),
+                                               module_name=(),
+                                               gpu=False,
+                                               cpu=False)
         out, err = capsys.readouterr()
         assert out == expected_output
         assert error.type == SystemExit
@@ -185,7 +197,11 @@ def test_plot_filter_dataframe_for_plotting_module_name(cli_runner, tmpdir, data
         input_df = pd.read_csv(data['testcsv.csv'])
 
         module = (module_name,)
-        real_df = plot.filter_dataframe_for_plotting(df=input_df, host_name=(), module_name=module, gpu=True, cpu=True)
+        real_df = plot.filter_dataframe_for_plotting(df=input_df,
+                                                     host_name=(),
+                                                     module_name=module,
+                                                     gpu=True,
+                                                     cpu=True)
 
         assert_frame_equal(expected_df, real_df)
 
@@ -206,6 +222,10 @@ def test_plot_filter_dataframe_for_plotting_host_name(cli_runner, tmpdir, data, 
 
         # I have to convert the variable to a tuple, otherwise this appears not to work
         host = (host_name,)
-        real_df = plot.filter_dataframe_for_plotting(df=input_df, host_name=host, module_name=(), gpu=True, cpu=True)
+        real_df = plot.filter_dataframe_for_plotting(df=input_df,
+                                                     host_name=host,
+                                                     module_name=(),
+                                                     gpu=True,
+                                                     cpu=True)
 
         assert_frame_equal(expected_df, real_df)

--- a/mdbenchmark/tests/test_plot.py
+++ b/mdbenchmark/tests/test_plot.py
@@ -32,61 +32,19 @@ from mdbenchmark.testing import data
 from mdbenchmark.ext.click_test import cli_runner
 
 
-# @pytest.mark.parametrize('module_selection', 'host', [
-#     ('gromacs/2018', 'draco'),
-#     ('namd/2.12', 'draco'),
-#     ('gromacs/2016.3', 'hydra')
-# ])
-# def test_plot_filtering_success(cli_runner, tmpdir, data module_selection, expected_df, host):
-#     """Test whether we can plot over different groups.
-#     """
-#     with tmpdir.as_cwd():
-#
-#         output = 'The following modules will be plotted {{'{}'}}.\n'.format{module_selection} \
-#                  'Your file was saved as testpng.png in the working directory.''
-#
-#         result = cli_runner.invoke(cli.cli, [
-#             'plot',
-#             '--csv=test.csv', '--module-name={}'.format(module_selection),
-#             '--host-name={}'.format(host), '--output-name=testpng'
-#         ])
-#         assert result.exit_code == 0
-#         assert result.output == output
-#         assert os.path.exists("testpng.png")
-
-# @pytest.mark.parametrize('module_selection', 'host', [
-#     ('gromacs/2018', 'failengine'),
-#     ('failengine', 'draco')
-# ])
-# def test_plot_filtering_fail(cli_runner, tmpdir, data, module_selection, host):
-#     """Test unsuccessful filtering and error message.
-#     """
-#     with tmpdir.as_cwd():
-#
-#         output = ''
-#
-#         result = cli_runner.invoke(cli.cli, [
-#             'plot',
-#             '--csv={}'.format(data['test.csv']), '--module-name={}'.format(module_selection),
-#             '--host-name={}'.format(host), '--output-name=testpng'
-#         ])
-#
-#         assert result.output == output
-#         assert result.exit_code == 1
-
-
 def test_plot_gpu(cli_runner, tmpdir, data):
     """Test gpu flage without any host or module.
     """
     with tmpdir.as_cwd():
-        output = 'All modules will be plotted.\n' \
-                 'All hosts will be plotted.\n' \
-                 'A total of 4 runs will be plotted.\n' \
-                 'Your file was saved as testpng.png in the working directory.\n' \
+
+        output = 'Plotting GPU and CPU data.\n' \
+                 'Plotting all hosts in csv.\n' \
+                 'Plotting all modules in your input data.\n' \
+                 'Your file was saved as testpng.png in the working directory.\n'
 
         result = cli_runner.invoke(cli.cli, [
             'plot',
-            '--csv={}'.format(data['test.csv']), '--gpu', '--output-name=testpng.png'
+            '--csv={}'.format(data['test.csv']), '--gpu', '--output-name=testpng', '--output-type=png'
         ])
 
         assert result.exit_code == 0
@@ -96,19 +54,19 @@ def test_plot_gpu(cli_runner, tmpdir, data):
 
 @pytest.mark.parametrize('host', ('draco', 'hydra'))
 def test_plot_host_only(cli_runner, tmpdir, host, data):
-    """Test only giving a host.
+    """Test plotting function with one given host.
     """
     with tmpdir.as_cwd():
 
-        output = 'All modules will be plotted.\n' \
-                 'Data for the following hosts will be plotted: {{\'{}\'}}.\n'\
-                 'A total of 1 runs will be plotted.\n' \
+        output = 'Plotting GPU and CPU data.\n' \
+                 'Data for the following hosts will be plotted: {{\'{}\'}}.\n' \
+                 'Plotting all modules in your input data.\n' \
                  'Your file was saved as testpng.png in the working directory.\n'.format(host)
 
         result = cli_runner.invoke(cli.cli, [
             'plot',
             '--csv={}'.format(data['test.csv']), '--host-name={}'.format(host),
-            '--output-name=testpng.png'
+            '--output-name=testpng', '--output-type=png'
         ])
 
         assert result.exit_code == 0
@@ -116,24 +74,37 @@ def test_plot_host_only(cli_runner, tmpdir, host, data):
         assert os.path.exists("testpng.png")
 
 
-# @pytest.mark.parametrize('module', ('gromacs', 'namd', 'namd/2.12', 'gromacs/2018'))
-# def test_plot_module_only(cli_runner, tmpdir, module):
-#     """Test only giving a module.
-#     """
-#     with tmpdir.as_cwd():
-#
-#         output = ''
-#
-#         result = cli_runner.invoke(cli.cli, [
-#             'plot',
-#             '--csv=test.csv', '--module-name={}'.format(module_selection),
-#             '--host-name={}'.format(host), '--output-name=testpng'
-#         ])
-#
-#
+@pytest.mark.parametrize('module', ('gromacs', 'namd', 'namd/2.12', 'gromacs/2018'))
+def test_plot_module_only(cli_runner, tmpdir, module, data):
+    """Test plotting function with one given engine or module.
+    """
+    with tmpdir.as_cwd():
+        if module in ['gromacs', 'namd']:
+            output = 'Plotting GPU and CPU data.\n' \
+                     'Plotting all hosts in csv.\n' \
+                     'Plotting all modules for engine {}.\n' \
+                     'Your file was saved as testpng.png in the working directory.\n'.format(module)
+        else:
+            output = 'Plotting GPU and CPU data.\n' \
+                     'Plotting all hosts in csv.\n' \
+                     'Plotting module {}.\n' \
+                     'Your file was saved as testpng.png in the working directory.\n'.format(module)
+
+        result = cli_runner.invoke(cli.cli, [
+            'plot',
+            '--csv={}'.format(data['test.csv']), '--module-name={}'.format(module),
+            '--output-name=testpng'
+        ])
+
+        assert result.exit_code == 0
+        assert result.output == output
+        assert os.path.exists("testpng.png")
+
+
+
 @pytest.mark.parametrize('output_type', ('png', 'pdf'))
 def test_plot_output_type(cli_runner, tmpdir, data, output_type):
-    """check whether output types are constructed correctly
+    """check whether output types are constructed correctly.
     """
     with tmpdir.as_cwd():
 
@@ -142,12 +113,17 @@ def test_plot_output_type(cli_runner, tmpdir, data, output_type):
                  'A total of 2 runs will be plotted.\n' \
                  'Your file was saved as test.{} in the working directory.\n'.format(output_type)
 
+        output = 'Plotting GPU and CPU data.\n' \
+                 'Plotting all hosts in csv.\n' \
+                 'Plotting all modules in your input data.\n' \
+                 'Your file was saved as testfile.{} in the working directory.\n'.format(output_type)
         result = cli_runner.invoke(cli.cli, [
             'plot',
             '--csv={}'.format(data['test.csv']), '--output-name=testfile', '--output-type={}'.format(output_type)
         ])
+        assert result.output == output
         assert result.exit_code == 0
-        assert os.path.exists("testfile.{}".format(output_type))
+        #assert os.path.exists("testfile.{}".format(output_type))
 
 
 @pytest.mark.parametrize("gpu,cpu", [
@@ -156,7 +132,7 @@ def test_plot_output_type(cli_runner, tmpdir, data, output_type):
     (False, True),
 ])
 def test_plot_filter_dataframe_for_plotting_gpu_and_cpu(cli_runner, tmpdir, data, gpu, cpu):
-    """ check whether output types are constructed correctly
+    """ Checks whether the cpu and gpu filtering works properly.
     """
     with tmpdir.as_cwd():
 
@@ -177,19 +153,20 @@ def test_plot_filter_dataframe_for_plotting_gpu_and_cpu(cli_runner, tmpdir, data
         assert_frame_equal(input_df, real_df)
 
 
-@pytest.mark.parametrize("gpu,cpu", [
-    (False, False)
-])
-def test_plot_filter_dataframe_for_plotting_gpu_and_cpu_fail(capsys, cli_runner, tmpdir, data, gpu, cpu):
-    """ check whether output types are constructed correctly
+def test_plot_filter_dataframe_for_plotting_gpu_and_cpu_fail(capsys, cli_runner, tmpdir, data):
+    """ Tests the error when gpu and cpu are set to false.
     """
     with tmpdir.as_cwd():
         input_df = pd.read_csv(data['testcsv.csv'])
 
-        expected_output = "CPU and GPU not set. Nothing to plot. Exiting."
-        plot.filter_dataframe_for_plotting(df=input_df, host_name=(), module_name=(), gpu=gpu, cpu=cpu)
+        expected_output = "ERROR CPU and GPU not set. Nothing to plot. Exiting.\n"
+        with pytest.raises(SystemExit) as error:
+            plot.filter_dataframe_for_plotting(df=input_df, host_name=(), module_name=(), gpu=False, cpu=False)
         out, err = capsys.readouterr()
         assert out == expected_output
+        assert error.type == SystemExit
+        assert error.value.code == 1
+
 
 @pytest.mark.parametrize('module_name', [
     ('namd/2.12'),
@@ -198,7 +175,7 @@ def test_plot_filter_dataframe_for_plotting_gpu_and_cpu_fail(capsys, cli_runner,
     ('namd')
 ])
 def test_plot_filter_dataframe_for_plotting_module_name(cli_runner, tmpdir, data, module_name):
-    """ check whether output types are constructed correctly
+    """ Checks whether the module names are filterd correctly in the filtering function.
     """
     with tmpdir.as_cwd():
 
@@ -218,7 +195,7 @@ def test_plot_filter_dataframe_for_plotting_module_name(cli_runner, tmpdir, data
     ('draco')
 ])
 def test_plot_filter_dataframe_for_plotting_host_name(cli_runner, tmpdir, data, host_name):
-    """ check whether output types are constructed correctly
+    """ Checks whether the host names are filtered correctly in the filtering function.
     """
     with tmpdir.as_cwd():
 

--- a/mdbenchmark/tests/test_plot.py
+++ b/mdbenchmark/tests/test_plot.py
@@ -22,10 +22,10 @@ import os
 import click
 import numpy as np
 import pandas as pd
+import pytest
 from numpy.testing import assert_equal
 from pandas.testing import assert_frame_equal
 
-import pytest
 from mdbenchmark import cli, plot, utils
 from mdbenchmark.ext.click_test import cli_runner
 from mdbenchmark.testing import data
@@ -61,7 +61,7 @@ def test_plot_host_only(cli_runner, tmpdir, host, data):
     with tmpdir.as_cwd():
 
         output = 'Plotting GPU and CPU data.\n' \
-                 'Data for the following hosts will be plotted: {{\'{}\'}}.\n' \
+                 'Data for the following hosts will be plotted: {}\n' \
                  'Plotting all modules in your input data.\n' \
                  'Your file was saved as testpng.png in the working directory.\n'.format(host)
 

--- a/mdbenchmark/tests/test_utils.py
+++ b/mdbenchmark/tests/test_utils.py
@@ -109,7 +109,7 @@ def test_calc_slope_intercept():
     slope = (y2 - y1) / (x2 - x1)
     intercept = y1 - (x1 * slope)
 
-    slope_intercept = utils.calc_slope_intercept(x1, y1, x2, y2)
+    slope_intercept = utils.calc_slope_intercept((x1, y1), (x2, y2))
 
     assert_equal(slope_intercept, np.hstack([slope, intercept]))
 

--- a/mdbenchmark/utils.py
+++ b/mdbenchmark/utils.py
@@ -91,10 +91,12 @@ def lin_func(x, m, b):
     return m * x + b
 
 
-def calc_slope_intercept(x1, y1, x2, y2):
-    slope = (y2 - y1) / (x2 - x1)
-    intercept = y1 - (x1 * slope)
-
+def calc_slope_intercept(x, y):
+    x = np.asarray(x)
+    y = np.asarray(y)
+    diff = x - y
+    slope = diff[1] / diff[0]
+    intercept = x[1] - (x[0] * slope)
     return np.hstack([slope, intercept])
 
 

--- a/mdbenchmark/utils.py
+++ b/mdbenchmark/utils.py
@@ -123,6 +123,6 @@ def guess_ncores():
 def generate_output_name(extension):
     """ generate a unique filename based on the date and time for a given extension.
     """
-    date_time = dt.datetime.now().strftime("%m%d%y_%H-%M")
+    date_time = dt.datetime.now().strftime("%Y%m%d_%H%M%S")
     out = '{}.{}'.format(date_time, extension)
     return out

--- a/mdbenchmark/utils.py
+++ b/mdbenchmark/utils.py
@@ -123,6 +123,6 @@ def guess_ncores():
 def generate_output_name(extension):
     """ generate a unique filename based on the date and time for a given extension.
     """
-    date_time = dt.datetime.now().strftime("%Y%m%d_%H%M%S")
+    date_time = dt.datetime.now().strftime("%Y-%m-%d_%H%M%S")
     out = '{}.{}'.format(date_time, extension)
     return out


### PR DESCRIPTION
Fixes #24

Updated plotting interface. `mdbenchmark analyze --plot` is not deprecated. Use `mdbenchmark plot` instead.

The new workflow for plotting data is as follows:

1) Use `mdbenchmark analyze` to generate a CSV output file.
2) Use `mdbenchmark plot --csv name_of_generated_file.csv` to plot the data.

Consult `mdbenchmark <command> --help` for options to filter your data accordingly.


PR Checklist
------------
 - [x] Added changelog fragment in  `./changelog/` ([more information](https://github.com/bio-phys/MDBenchmark/blob/master/DEVELOPER.rst#using-towncrier))?
 - [x] Issue raised/referenced?

