### PR TITLE
be case insensitive for module names

### DIFF
--- a/changelog/61.bugfix
+++ b/changelog/61.bugfix
@@ -1,0 +1,1 @@
+module names are checked case insensitive

--- a/mdbenchmark/mdengines/__init__.py
+++ b/mdbenchmark/mdengines/__init__.py
@@ -41,7 +41,7 @@ def detect_md_engine(modulename):
     """
 
     for name, engine in six.iteritems(SUPPORTED_ENGINES):
-        if name in modulename:
+        if name in modulename.lower():
             return engine
 
     return None

--- a/mdbenchmark/tests/mdengines/test_init.py
+++ b/mdbenchmark/tests/mdengines/test_init.py
@@ -52,16 +52,23 @@ def test_prepare_module_name(capsys):
     assert prepare_module_name('gromacs/2016.4')
 
 
-def test_detect_md_engine():
+@pytest.mark.parametrize('arg, out',
+                         (('gromacs/2016.3', 'mdbenchmark.mdengines.gromacs'),
+                          ('namd/123', 'mdbenchmark.mdengines.namd'),
+                          ('NAMD/123', 'mdbenchmark.mdengines.namd'),
+                          ('NamD/123', 'mdbenchmark.mdengines.namd'),
+                          ('GROMACS/123', 'mdbenchmark.mdengines.gromacs'),
+                          ('GRomacS/123', 'mdbenchmark.mdengines.gromacs')))
+def test_detect_md_engine_supported(arg, out):
     """Test that we only accept supported MD engines."""
+    engine = detect_md_engine(arg)
+    assert engine.__name__ == out
 
-    engine = detect_md_engine('gromacs/2016.3')
-    assert engine.__name__ == 'mdbenchmark.mdengines.gromacs'
 
-    engine = detect_md_engine('namd/123')
-    assert engine.__name__ == 'mdbenchmark.mdengines.namd'
-
-    assert detect_md_engine('someengine/123') is None
+def test_detect_md_engine_unkown():
+    """Test that we return None for unkown engines"""
+    engine = detect_md_engine('someengine/123')
+    assert engine is None
 
 
 def test_normalize_modules(capsys, monkeypatch, tmpdir):


### PR DESCRIPTION
fixes #61

Changes made in this pull request:
- module name detection is case insensitive 


PR Checklist
------------
 - [x] Added changelog fragment in  `./changelog/` ([more information](https://github.com/bio-phys/MDBenchmark/blob/master/DEVELOPER.rst#using-towncrier))?
 - [x] Issue raised/referenced?
