### PR TITLE
Enhance usability when using `--skip-validation`.

### DIFF
--- a/changelog/74.misc
+++ b/changelog/74.misc
@@ -1,0 +1,1 @@
+Added new error message when running `mdbenchmark generate [...] --skip-validation` without providing a supported MD engine.

--- a/mdbenchmark/mdengines/__init__.py
+++ b/mdbenchmark/mdengines/__init__.py
@@ -47,7 +47,7 @@ def detect_md_engine(modulename):
     return None
 
 
-def prepare_module_name(module):
+def prepare_module_name(module, skip_validation=False):
     """Split the provided module name into its base MD engine and version.
 
     Currently we only try to split via the delimiter `/`, but this could be
@@ -56,6 +56,10 @@ def prepare_module_name(module):
     try:
         basename, version = module.split('/')
     except (ValueError, AttributeError) as e:
+        if skip_validation:
+            console.error('Although you are using the {} option, you have to provide a valid '
+                          'MD engine name, e.g., {} or {}.',
+                          '--skip-validation', 'gromacs/dummy', 'namd/dummy')
         console.error('We were not able to determine the module name.')
 
     return basename, version
@@ -106,7 +110,7 @@ def normalize_modules(modules, skip_validation):
     # Check if modules are from supported md engines
     d = defaultdict(list)
     for m in modules:
-        engine_name, version = prepare_module_name(m)
+        engine_name, version = prepare_module_name(m, skip_validation)
         d[engine_name] = version
     for engine_name in d.keys():
         if detect_md_engine(engine_name) is None:

--- a/mdbenchmark/tests/mdengines/test_init.py
+++ b/mdbenchmark/tests/mdengines/test_init.py
@@ -20,7 +20,6 @@
 import os
 
 import pytest
-
 from mdbenchmark import cli
 from mdbenchmark.ext.click_test import cli_runner
 from mdbenchmark.mdengines import (detect_md_engine, get_available_modules,
@@ -44,10 +43,21 @@ def test_prepare_module_name(capsys):
     # Fail state
     with pytest.raises(SystemExit) as e:
         prepare_module_name('gromacs-2016.4')
-        out, err = capsys.readouterr()
         assert e.type == SystemExit
         assert e.code == 1
-        assert out == 'ERROR We were not able to determine the module name.\n'
+
+    out, err = capsys.readouterr()
+    assert out == 'ERROR We were not able to determine the module name.\n'
+
+    # Second fail state
+    with pytest.raises(SystemExit) as e:
+        prepare_module_name('whatever', skip_validation=True)
+        assert e.type == SystemExit
+        assert e.code == 1
+
+    out, err = capsys.readouterr()
+    assert out == 'ERROR Although you are using the --skip-validation option, you have to ' \
+                  'provide a valid MD engine name, e.g., gromacs/dummy or namd/dummy.\n'
 
     assert prepare_module_name('gromacs/2016.4')
 


### PR DESCRIPTION
Fixes #73 

Changes made in this pull request:
- Added new error message when running `mdbenchmark generate [...] --skip-validation` without providing a supported MD engine.


PR Checklist
------------
 - [x] Added changelog fragment in  `./changelog/` ([more information](https://github.com/bio-phys/MDBenchmark/blob/master/DEVELOPER.rst#using-towncrier))?
 - [x] Issue raised/referenced?
