### PR TITLE
Enforce code formatting with black

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,15 +34,21 @@ matrix:
       language: python
       python: "3.6"
       env: SKIP_INSTALL=true
+           TEST_FORMATTING=true
+           MAIN_CMD="black --check setup.py mdbenchmark"
+           SETUP_CMD=""
 
 install:
-  - if [ -z ${SKIP_INSTALL+x} ]; then git clone git://github.com/astropy/ci-helpers.git; fi
-  - if [ -z ${SKIP_INSTALL+x} ]; then source ci-helpers/travis/setup_conda.sh; fi
-  - if [ -z ${SKIP_INSTALL+x} ]; then pip install -e .; fi
-  - if [ ! -z ${SKIP_INSTALL+x} ]; then pip install black; fi
+  - |
+    if [ -z ${SKIP_INSTALL+x} ]; then \
+      git clone git://github.com/astropy/ci-helpers.git; \
+      source ci-helpers/travis/setup_conda.sh; \
+      pip install -e .; \
+    fi
+  - if [ ! -z ${TEST_FORMATTING+x} ]; then pip install black; fi
 
 script:
-  - if [ -z {$SKIP_INSTALL+x} ]; then $MAIN_CMD $SETUP_CMD; else black --check setup.py mdbenchmark/; fi
+  - $MAIN_CMD $SETUP_CMD
 
 after_success:
-  - codecov
+  - if [[ "$PYTHON_VERSION" == "3.6" ]]; then codecov; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,13 +30,19 @@ matrix:
            MAIN_CMD="rst-lint README.rst"
            SETUP_CMD=""
 
+    - os: linux
+      language: python
+      python: "3.6"
+      env: SKIP_INSTALL=true
+
 install:
-  - git clone git://github.com/astropy/ci-helpers.git
-  - source ci-helpers/travis/setup_conda.sh
-  - pip install -e .
+  - if [ -z ${SKIP_INSTALL+x} ]; then git clone git://github.com/astropy/ci-helpers.git; fi
+  - if [ -z ${SKIP_INSTALL+x} ]; then source ci-helpers/travis/setup_conda.sh; fi
+  - if [ -z ${SKIP_INSTALL+x} ]; then pip install -e .; fi
+  - if [ ! -z ${SKIP_INSTALL+x} ]; then pip install black; fi
 
 script:
-  - $MAIN_CMD $SETUP_CMD
+  - if [ -z {$SKIP_INSTALL+x} ]; then $MAIN_CMD $SETUP_CMD; else black --check setup.py mdbenchmark/; fi
 
 after_success:
   - codecov


### PR DESCRIPTION
Changes made in this pull request:
- Add `black` to `.travis.yml`, to check for formatting issues. Builds will fail, if `black` would reformat any files inside of `mdbenchmark/`.
`black` only supports Python 3.6, so we need to run it in its own job on Travis.
- Go and install `black` via `pip install --user black` onto your system and make sure to run it, before submitting code. `black` integrates into a variety of editors, see [`black` README](https://github.com/ambv/black/blob/master/README.md#editor-integration).

PR Checklist
------------
 - ~[ ] Added changelog fragment in  `./changelog/` ([more information](https://github.com/bio-phys/MDBenchmark/blob/master/DEVELOPER.rst#using-towncrier))?~
 - ~[ ] Issue raised/referenced?~
