### PR TITLE
Fixed Bug in Plotting for single datapoint

### DIFF
--- a/mdbenchmark/plot.py
+++ b/mdbenchmark/plot.py
@@ -30,7 +30,10 @@ from .utils import calc_slope_intercept, generate_output_name, lin_func
 
 plt.switch_backend("agg")
 
+
 def plot_projection(df, selection, color, ax=None):
+    if ax is None:
+        ax = plt.gca()
     slope, intercept = calc_slope_intercept(
         (df[selection].iloc[0], df["ns/day"].iloc[0]),
         (df[selection].iloc[1], df["ns/day"].iloc[1]),

--- a/mdbenchmark/plot.py
+++ b/mdbenchmark/plot.py
@@ -30,13 +30,7 @@ from .utils import calc_slope_intercept, generate_output_name, lin_func
 
 plt.switch_backend("agg")
 
-
-def plot_line(df, selection, label, ax=None):
-    if ax is None:
-        ax = plt.gca()
-
-    p = ax.plot(selection, "ns/day", ".-", data=df, ms="10", label=label)
-    color = p[0].get_color()
+def plot_projection(df, selection, color, ax=None):
     slope, intercept = calc_slope_intercept(
         (df[selection].iloc[0], df["ns/day"].iloc[0]),
         (df[selection].iloc[1], df["ns/day"].iloc[1]),
@@ -49,6 +43,19 @@ def plot_line(df, selection, label, ax=None):
         color=color,
         alpha=.5,
     )
+    return ax
+
+
+def plot_line(df, selection, label, ax=None):
+    if ax is None:
+        ax = plt.gca()
+
+    p = ax.plot(selection, "ns/day", ".-", data=df, ms="10", label=label)
+    color = p[0].get_color()
+
+    if len(df[selection]) > 1:
+        plot_projection(df=df, selection=selection, color=color, ax=ax)
+
     return ax
 
 

--- a/mdbenchmark/tests/test_plot.py
+++ b/mdbenchmark/tests/test_plot.py
@@ -30,6 +30,10 @@ from mdbenchmark import cli, plot, utils
 from mdbenchmark.ext.click_test import cli_runner
 from mdbenchmark.testing import data
 
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
+from matplotlib.figure import Figure
+
 
 def test_plot_gpu(cli_runner, tmpdir, data):
     """Test gpu flage without any host or module.
@@ -271,3 +275,42 @@ def test_plot_filter_empty_dataframe_error(cli_runner, capsys, tmpdir, data):
         assert out == expected_output
         assert error.type == SystemExit
         assert error.value.code == 1
+
+
+def test_plot_plot_projection(capsys, cli_runner, tmpdir, data):
+    """Assert whether the line projection function returns an ax object.
+    """
+    df = pd.read_csv(data["testcsv.csv"])
+    df = df[:2]
+    selection = "nodes"
+    color = "grey"
+    fig = Figure()
+    FigureCanvas(fig)
+    ax = fig.add_subplot(111)
+    plot.plot_projection(df=df, selection=selection, color=color, ax=ax)
+
+
+def test_plot_plot_line(capsys, cli_runner, tmpdir, data):
+    """Assert whether the single plot entry works and returns an ax object.
+    """
+    df = pd.read_csv(data["testcsv.csv"])
+    df = df[:2]
+    selection = "nodes"
+    label = "test"
+    fig = Figure()
+    FigureCanvas(fig)
+    ax = fig.add_subplot(111)
+    plot.plot_line(df=df, selection=selection, label=label, ax=ax)
+
+
+def test_plot_plot_line_singlepoint(capsys, cli_runner, tmpdir, data):
+    """Assert whether the single plot entry works and returns an ax object.
+    """
+    df = pd.read_csv(data["testcsv.csv"])
+    df = df[:1]
+    selection = "nodes"
+    label = "test"
+    fig = Figure()
+    FigureCanvas(fig)
+    ax = fig.add_subplot(111)
+    plot.plot_line(df=df, selection=selection, label=label, ax=ax)


### PR DESCRIPTION
Fixes #81 

Changes made in this pull request:
- moved line projection plotting to new function
- fixed bug where plotting failed with a single datapoint and the projection couldn't be calculated.


PR Checklist
------------
 - [ ] Added changelog fragment in  `./changelog/` ([more information](https://github.com/bio-phys/MDBenchmark/blob/master/DEVELOPER.rst#using-towncrier))?
 - [ ] Issue raised/referenced?
