### PR TITLE
Short option to negate CPU/GPU selection

### DIFF
--- a/mdbenchmark/generate.py
+++ b/mdbenchmark/generate.py
@@ -119,7 +119,7 @@ def validate_hosts(ctx, param, host=None):
     callback=validate_name,
 )
 @click.option(
-    "-c",
+    "-c/-nc",
     "--cpu/--no-cpu",
     is_flag=True,
     help="Use CPUs for benchmark.",
@@ -127,7 +127,7 @@ def validate_hosts(ctx, param, host=None):
     show_default=True,
 )
 @click.option(
-    "-g",
+    "-g/-ng",
     "--gpu/--no-gpu",
     is_flag=True,
     help="Use GPUs for benchmark.",


### PR DESCRIPTION
Changes made in this pull request:
- Added `-nc` and `-ng` option. This is the short equivalent to `--no-cpu` and `--no-gpu`.

PR Checklist
------------
 - [x] Added changelog fragment in  `./changelog/` ([more information](https://github.com/bio-phys/MDBenchmark/blob/master/DEVELOPER.rst#using-towncrier))?
 - [ ] Issue raised/referenced?
