### PR TITLE
Pin python dependencies in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,13 +71,13 @@ setup(
     packages=find_packages(),
     install_requires=[
         "numpy>=1.8",
-        "mdsynthesis",
-        "click",
+        "mdsynthesis==0.6.1",
+        "click==6.7",  # v7.0 introduced some changes that broke our tests.
         "jinja2",
         "pandas",
-        "matplotlib",
+        "matplotlib>=2.2.3,<3.0",  # matplotlib 3.0 does not support Python 2
         "python-Levenshtein",
-        "xdg<2",
+        "xdg<2",  # xdg 2 does not support Python 2
     ],
     package_data={"mdbenchmark": ["templates/*"]},
     entry_points={"console_scripts": ["mdbenchmark=mdbenchmark.cli:cli"]},


### PR DESCRIPTION
A recent Click update (version 7.0) broke a simple unit test (added a new output line). Also `matplotlib==3.0` dropped Python 2 support. We pinned the latter to the latest LTS version, and the former to version 6.7.

Also pinned some other python packages that made sense.
