### PR TITLE
Add --template option to generate

### DIFF
--- a/changelog/106.feature
+++ b/changelog/106.feature
@@ -1,0 +1,1 @@
+Added ``--template`` and ``-t`` option to ``mdbenchmark generate``, to specify a job template. The ``--host`` option still works.

--- a/mdbenchmark/generate.py
+++ b/mdbenchmark/generate.py
@@ -141,7 +141,12 @@ def validate_hosts(ctx, param, host=None):
     callback=validate_module,
 )
 @click.option(
-    "--host", help="Name of the job template.", default=None, callback=validate_hosts
+    "-t",
+    "--template",
+    "--host",
+    help="Name of the job template.",
+    default=None,
+    callback=validate_hosts,
 )
 @click.option(
     "--min-nodes",

--- a/mdbenchmark/tests/test_generate.py
+++ b/mdbenchmark/tests/test_generate.py
@@ -165,7 +165,7 @@ def test_generate_simple_input_with_cpu_gpu(
             [
                 "generate",
                 "--module={}".format(module),
-                "--host=draco",
+                "--template=draco",
                 "--max-nodes=4",
                 "--gpu",
                 "--name=protein",
@@ -203,7 +203,7 @@ def test_generate_simple_input_with_working_validation(
             [
                 "generate",
                 "--module={}".format(module),
-                "--host=draco",
+                "--template=draco",
                 "--max-nodes=4",
                 "--gpu",
                 "--no-cpu",


### PR DESCRIPTION
Fixes #105

Changes made in this pull request:
- Added `mdbenchmark generate --template` and `mdbenchmark generate -t` as a new default for `mdbenchmark generate --host`. The latter still works.


PR Checklist
------------
 - [x] Added changelog fragment in  `./changelog/` ([more information](https://github.com/bio-phys/MDBenchmark/blob/master/DEVELOPER.rst#using-towncrier))?
 - [x] Issue raised/referenced?
