### PR TITLE
Update CLI options

### DIFF
--- a/changelog/107.feature
+++ b/changelog/107.feature
@@ -1,0 +1,1 @@
+Standarize the CLI options across all `mdbenchmark` calls.

--- a/mdbenchmark/analyze.py
+++ b/mdbenchmark/analyze.py
@@ -44,21 +44,41 @@ plt.switch_backend("agg")
     show_default=True,
 )
 @click.option(
-    "-p", "--plot", is_flag=True, help="Generate a plot of finished benchmarks."
+    "-p",
+    "--plot",
+    is_flag=True,
+    help="DEPRECATED. Please use 'mdbenchmark plot'.\nGenerate a plot of finished benchmarks.",
 )
 @click.option(
     "--ncores",
+    "--number-cores",
+    "ncores",
     type=int,
     default=None,
-    help="Number of cores per node. If not given it will be parsed from the "
-    "benchmarks log file.",
+    help="Number of cores per node. If not given it will be parsed from the benchmarks' log file.",
     show_default=True,
 )
 @click.option(
-    "-o", "--output-name", default=None, help="Name of the output CSV file.", type=str
+    "-o",
+    "--output-name",
+    default=None,
+    help="Filename for the CSV file containing benchmark results.",
+    type=str,
 )
 def analyze(directory, plot, ncores, output_name):
-    """Analyze finished benchmarks."""
+    """Analyze benchmarks and print the performance results.
+
+    Benchmarks are searched recursively starting from the directory specified
+    in `--directory`. If the option is not specified, the working directory
+    will be used.
+
+    Benchmarks that have not started yet or finished without printing the
+    performance result, will be marked accordingly.
+
+    The benchmark performance results can be saved in a CSV file with the
+    `--output-name` option and a custom filename. To plot the results use
+    `mdbenchmark plot`.
+    """
     bundle = mds.discover(directory)
 
     df = pd.DataFrame(
@@ -103,10 +123,7 @@ def analyze(directory, plot, ncores, output_name):
     df.to_csv(output_name)
 
     if plot:
-        console.warn(
-            "This feature is deprecated. Please use '{}' in the future.",
-            "mdbenchmark plot",
-        )
+        console.warn("'--plot' has been deprecated, use '{}'.", "mdbenchmark plot")
 
         fig = Figure()
         FigureCanvas(fig)

--- a/mdbenchmark/generate.py
+++ b/mdbenchmark/generate.py
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with MDBenchmark.  If not, see <http://www.gnu.org/licenses/>.
 import click
+
 import datreant.core as dtr
 
 from . import console, mdengines, utils
@@ -144,7 +145,7 @@ def validate_hosts(ctx, param, host=None):
     "-t",
     "--template",
     "--host",
-    help="Name of the job template.",
+    help="Name of the host template.",
     default=None,
     callback=validate_hosts,
 )
@@ -171,7 +172,7 @@ def validate_hosts(ctx, param, host=None):
 )
 @click.option(
     "--list-hosts",
-    help="Show available job templates.",
+    help="Show available host templates.",
     is_flag=True,
     is_eager=True,
     callback=print_known_hosts,
@@ -184,7 +185,26 @@ def validate_hosts(ctx, param, host=None):
     is_flag=True,
 )
 def generate(name, cpu, gpu, module, host, min_nodes, max_nodes, time, skip_validation):
-    """Generate benchmarks simulations from the CLI."""
+    """Generate benchmarks for molecular dynamics simulations.
+
+    Requires the `--name` option to be provided an existing file, e.g.,
+    `protein.tpr` for GROMACS and `protein.namd`, `protein.pdb` and
+    `protein.psf` for NAMD. The filename `protein` will then be used as the job
+    name.
+
+    The specified module name will be validated and searched on the current
+    system. To skip this check, use the `--skip-validation` option.
+
+    Benchmarks will be generated for CPUs per default (`--cpu`), but can also
+    be generated for GPUs (`--gpu`) at the same time or without CPUs
+    (`--no-cpu`).
+
+    The hostname of the current system will be used to look for benchmark
+    templates, but can be overwritten with the `--template` option. Templates
+    for the MPCDF clusters `cobra`, `draco` and `hydra` are provided with the
+    package. All available templates can be listed with the `--list-hosts`
+    option.
+    """
     # Validate the CPU and GPU flags
     validate_cpu_gpu_flags(cpu, gpu)
 

--- a/mdbenchmark/submit.py
+++ b/mdbenchmark/submit.py
@@ -22,6 +22,7 @@ import subprocess
 from glob import glob
 
 import click
+
 import mdsynthesis as mds
 
 from . import console
@@ -60,14 +61,14 @@ def get_batch_command():
     is_flag=True,
 )
 def submit(directory, force_restart):
-    """Submit benchmarks to queuing system.
+    """Submit generated benchmarks to a queuing system.
 
-    benchmarks are searched recursively starting from the directory specified
-    in `--directory`.
+    Benchmarks are searched recursively starting from the directory specified
+    in `--directory`. If the option is not specified, the working directory
+    will be used.
 
-    Checks whether benchmark folders were already generated, exits otherwise.
-    Only runs benchmarks that were not already started. Can be overwritten with
-    `--force`.
+    Benchmarks will not be submitted, if they were already started. This
+    behaviour can be overwritten with `--force`.
     """
     bundle = mds.discover(directory)
 

--- a/mdbenchmark/tests/test_plot.py
+++ b/mdbenchmark/tests/test_plot.py
@@ -54,7 +54,7 @@ def test_plot_gpu(cli_runner, tmpdir, data):
                 "--csv={}".format(data["test.csv"]),
                 "--gpu",
                 "--output-name=testpng",
-                "--output-type=png",
+                "--output-format=png",
             ],
         )
 
@@ -83,9 +83,9 @@ def test_plot_host_only(cli_runner, tmpdir, host, data):
             [
                 "plot",
                 "--csv={}".format(data["test.csv"]),
-                "--host-name={}".format(host),
+                "--host={}".format(host),
                 "--output-name=testpng",
-                "--output-type=png",
+                "--output-format=png",
             ],
         )
 
@@ -123,7 +123,7 @@ def test_plot_module_only(cli_runner, tmpdir, module, data):
             [
                 "plot",
                 "--csv={}".format(data["test.csv"]),
-                "--module-name={}".format(module),
+                "--module={}".format(module),
                 "--output-name=testpng",
             ],
         )
@@ -161,7 +161,7 @@ def test_plot_output_type(cli_runner, tmpdir, data, output_type):
                 "plot",
                 "--csv={}".format(data["test.csv"]),
                 "--output-name=testfile",
-                "--output-type={}".format(output_type),
+                "--output-format={}".format(output_type),
             ],
         )
         assert result.output == output


### PR DESCRIPTION
Fixes #102.

Changes made in this pull request:
- Added `--number-cores` to `mdbenchmark analyze`.
- Renamed `--module-name` to `--module` in `mdbenchmark plot`.
- Renamed `--host-name` to `--host` in `mdbenchmark plot`.
- Added `--template` and `-t` to `mdbenchmark plot`. It's a synonym for `mdbenchmark `-host`
- Added `-c/-nc` and `-g/-ng` short options for `--cpu/--no-cpu` and `--gpu/--no-gpu`, respectively.
- Renamed `--output-type` to `--output-format`.
- Renamed `-t` as short option to `-f`.

PR Checklist
------------
 - [x] Added changelog fragment in  `./changelog/` ([more information](https://github.com/bio-phys/MDBenchmark/blob/master/DEVELOPER.rst#using-towncrier))?
 - [x] Issue raised/referenced?
