### PR TITLE
Update plot style

### DIFF
--- a/changelog/108.feature.1
+++ b/changelog/108.feature.1
@@ -1,0 +1,1 @@
+Added ``mdbenchmark plot --dpi`` option to change the plot DPI.

--- a/changelog/108.feature.2
+++ b/changelog/108.feature.2
@@ -1,0 +1,1 @@
+Added ``mdbenchmark plot --font-size`` to change the plot font size.

--- a/changelog/108.feature.3
+++ b/changelog/108.feature.3
@@ -1,0 +1,1 @@
+Updated ``ylim``, ``xtick``  and ``ytick`` defaults. The steps for ``xtick`` can be overwritten with ``mdbenchmark plot --xtick-step``.

--- a/changelog/108.feature.4
+++ b/changelog/108.feature.4
@@ -1,0 +1,1 @@
+Added a watermark in the top left corner for every plot. Can be easiliy disabled with ``mdbenchmark plot --no-watermark``.

--- a/changelog/108.feature.5
+++ b/changelog/108.feature.5
@@ -1,0 +1,1 @@
+Linear scaling fit can now be hidden with ``--no-fit``.

--- a/mdbenchmark/plot.py
+++ b/mdbenchmark/plot.py
@@ -240,6 +240,13 @@ def plot(
     FigureCanvas(fig)
     ax = fig.add_subplot(111)
     ax = plot_over_group(df, plot_cores, ax=ax)
+    # Update yticks
+    max_y = df["ns/day"].max() or 50
+    yticks_steps = ((max_y + 1) / 10).astype(int)
+    yticks = np.arange(0, max_y + (max_y * 0.25), yticks_steps)
+    ax.set_yticks(yticks)
+    ax.set_ylim(0, max_y + (max_y * 0.25))
+
     lgd = ax.legend(loc="upper center", bbox_to_anchor=(0.5, -0.175))
     plt.tight_layout()
 

--- a/mdbenchmark/plot.py
+++ b/mdbenchmark/plot.py
@@ -191,7 +191,8 @@ def filter_dataframe_for_plotting(df, host_name, module_name, gpu, cpu):
     show_default=True,
     is_flag=True,
 )
-def plot(csv, output_name, output_format, template, module, gpu, cpu, plot_cores):
+@click.option("--dpi", help="Dots per inch (DPI) for generated plot.", default=300, show_default=True)
+def plot(csv, output_name, output_format, template, module, gpu, cpu, plot_cores, dpi):
     """Generate plots showing the benchmark performance.
 
     To generate a plot, you must first run `mdbenchmark analyze` and generate a
@@ -232,6 +233,10 @@ def plot(csv, output_name, output_format, template, module, gpu, cpu, plot_cores
     # therefore i add it manually as extra artist. This way we don't get problems
     # with the variability of individual lines which are to be plotted
     fig.savefig(
-        output_name, type=output_format, bbox_extra_artists=(lgd,), bbox_inches="tight"
+        output_name,
+        type=output_format,
+        bbox_extra_artists=(lgd,),
+        bbox_inches="tight",
+        dpi=dpi,
     )
     console.info("Your file was saved as '{}' in the working directory.", output_name)

--- a/mdbenchmark/plot.py
+++ b/mdbenchmark/plot.py
@@ -232,6 +232,13 @@ def filter_dataframe_for_plotting(df, host_name, module_name, gpu, cpu):
     default=300,
     show_default=True,
 )
+@click.option(
+    "--watermark/--no-watermark",
+    help="Puts a watermark in the top left corner of the generated plot.",
+    default=True,
+    show_default=True,
+    is_flag=True,
+)
 def plot(
     csv,
     output_name,
@@ -243,6 +250,7 @@ def plot(
     plot_cores,
     font_size,
     dpi,
+    watermark,
 ):
     """Generate plots showing the benchmark performance.
 
@@ -255,6 +263,10 @@ def plot(
 
     To only plot specific benchmarks, make use of the `--module`, `--template`,
     `--cpu/--no-cpu` and `--gpu/--no-gpu` options.
+
+    A small watermark will be added to the top left corner of every plot, to
+    spread the usage of MDBenchmark. You can remove the watermark with the
+    `--no-watermark` option.
     """
 
     if not csv:
@@ -288,6 +300,10 @@ def plot(
     yticks = np.arange(0, max_y + (max_y * 0.25), yticks_steps)
     ax.set_yticks(yticks)
     ax.set_ylim(0, max_y + (max_y * 0.25))
+
+    # Add watermark
+    if watermark:
+        ax.text(0.025, 0.925, "MDBenchmark", transform=ax.transAxes, alpha=0.3)
 
     lgd = ax.legend(loc="upper center", bbox_to_anchor=(0.5, -0.175))
     plt.tight_layout()

--- a/mdbenchmark/plot.py
+++ b/mdbenchmark/plot.py
@@ -233,6 +233,9 @@ def filter_dataframe_for_plotting(df, host_name, module_name, gpu, cpu):
     show_default=True,
 )
 @click.option(
+    "--xtick-step", help="Override the step for xticks in the generated plot.", type=int
+)
+@click.option(
     "--watermark/--no-watermark",
     help="Puts a watermark in the top left corner of the generated plot.",
     default=True,
@@ -250,6 +253,7 @@ def plot(
     plot_cores,
     font_size,
     dpi,
+    xtick_step,
     watermark,
 ):
     """Generate plots showing the benchmark performance.

--- a/mdbenchmark/plot.py
+++ b/mdbenchmark/plot.py
@@ -74,20 +74,20 @@ def plot_projection(df, selection, color, ax=None):
     return ax
 
 
-def plot_line(df, selection, label, ax=None):
+def plot_line(df, selection, label, fit, ax=None):
     if ax is None:
         ax = plt.gca()
 
     p = ax.plot(selection, "ns/day", ".-", data=df, ms="10", label=label)
     color = p[0].get_color()
 
-    if len(df[selection]) > 1:
+    if fit and (len(df[selection]) > 1):
         plot_projection(df=df, selection=selection, color=color, ax=ax)
 
     return ax
 
 
-def plot_over_group(df, plot_cores, ax=None):
+def plot_over_group(df, plot_cores, fit, ax=None):
     # plot all lines
     selection = "ncores" if plot_cores else "nodes"
 
@@ -101,7 +101,7 @@ def plot_over_group(df, plot_cores, ax=None):
         label = "{template} - {module} on {pu}s".format(
             template=template, module=module, pu=pu
         )
-        plot_line(df=df, selection=selection, ax=ax, label=label)
+        plot_line(df=df, selection=selection, ax=ax, fit=fit, label=label)
 
     # style axes
     xlabel = "cores" if plot_cores else "nodes"
@@ -222,6 +222,12 @@ def filter_dataframe_for_plotting(df, host_name, module_name, gpu, cpu):
     is_flag=True,
 )
 @click.option(
+    "--fit/--no-fit",
+    help="Fit a line through the first two data points, indicating linear scaling.",
+    show_default=True,
+    default=True,
+)
+@click.option(
     "--font-size", help="Font size for generated plot.", default=16, show_default=True
 )
 @click.option(
@@ -249,6 +255,7 @@ def plot(
     gpu,
     cpu,
     plot_cores,
+    fit,
     font_size,
     dpi,
     xtick_step,
@@ -261,7 +268,9 @@ def plot(
     command.
 
     You can customize the filename and file format of the generated plot with
-    the `--output-name` and `--format` option, respectively.
+    the `--output-name` and `--format` option, respectively. Per default, a fit
+    will be plotted through the first data points of each benchmark group. To
+    disable the fit, use the `--no-fit` option.
 
     To only plot specific benchmarks, make use of the `--module`, `--template`,
     `--cpu/--no-cpu` and `--gpu/--no-gpu` options.
@@ -284,7 +293,7 @@ def plot(
     fig = Figure()
     FigureCanvas(fig)
     ax = fig.add_subplot(111)
-    ax = plot_over_group(df, plot_cores, ax=ax)
+    ax = plot_over_group(df=df, plot_cores=plot_cores, fit=fit, ax=ax)
 
     # Update xticks
     selection = "ncores" if plot_cores else "nodes"

--- a/mdbenchmark/plot.py
+++ b/mdbenchmark/plot.py
@@ -96,7 +96,13 @@ def plot_over_group(df, plot_cores, ax=None):
     groupby = ["gpu", "module", "host"]
     gb = df.groupby(groupby)
     for key, df in gb:
-        label = " ".join(["{}={}".format(n, v) for n, v in zip(groupby, key)])
+        template = key[2]
+        module = key[1]
+        pu = "GPU" if key[0] else "CPU"
+
+        label = "{template} - {module} on {pu}s".format(
+            template=template, module=module, pu=pu
+        )
         plot_line(df=df, selection=selection, ax=ax, label=label)
 
     # style axes

--- a/mdbenchmark/plot.py
+++ b/mdbenchmark/plot.py
@@ -22,6 +22,7 @@ import click
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+from matplotlib import rcParams as mpl_rcParams
 from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
 from matplotlib.figure import Figure
 
@@ -191,8 +192,27 @@ def filter_dataframe_for_plotting(df, host_name, module_name, gpu, cpu):
     show_default=True,
     is_flag=True,
 )
-@click.option("--dpi", help="Dots per inch (DPI) for generated plot.", default=300, show_default=True)
-def plot(csv, output_name, output_format, template, module, gpu, cpu, plot_cores, dpi):
+@click.option(
+    "--font-size", help="Font size for generated plot.", default=16, show_default=True
+)
+@click.option(
+    "--dpi",
+    help="Dots per inch (DPI) for generated plot.",
+    default=300,
+    show_default=True,
+)
+def plot(
+    csv,
+    output_name,
+    output_format,
+    template,
+    module,
+    gpu,
+    cpu,
+    plot_cores,
+    font_size,
+    dpi,
+):
     """Generate plots showing the benchmark performance.
 
     To generate a plot, you must first run `mdbenchmark analyze` and generate a
@@ -215,6 +235,7 @@ def plot(csv, output_name, output_format, template, module, gpu, cpu, plot_cores
 
     df = filter_dataframe_for_plotting(df, template, module, gpu, cpu)
 
+    mpl_rcParams["font.size"] = font_size
     fig = Figure()
     FigureCanvas(fig)
     ax = fig.add_subplot(111)

--- a/mdbenchmark/plot.py
+++ b/mdbenchmark/plot.py
@@ -65,14 +65,12 @@ def plot_projection(df, selection, color, ax=None):
         (df[selection].iloc[0], df["ns/day"].iloc[0]),
         (df[selection].iloc[1], df["ns/day"].iloc[1]),
     )
+    xstep = df[selection].iloc[1] - df[selection].iloc[0]
+    xmax = df[selection].iloc[-1] + xstep
+    x = df[selection]
+    x = pd.concat([pd.DataFrame({0: [0]}), x, pd.DataFrame({0: [xmax]})])
     # avoid a label and use values instead of pd.Series
-    ax.plot(
-        df[selection],
-        lin_func(df[selection].values, slope, intercept),
-        ls="--",
-        color=color,
-        alpha=0.5,
-    )
+    ax.plot(x, lin_func(x.values, slope, intercept), ls="--", color=color, alpha=0.5)
     return ax
 
 
@@ -297,6 +295,8 @@ def plot(
     step = get_xsteps(xticks.size, min_x, plot_cores, xtick_step)
 
     ax.set_xticks(xticks[::step])
+    xdiff = min_x * 0.5 * step
+    ax.set_xlim(min_x - xdiff, max_x + xdiff)
 
     # Update yticks
     max_y = df["ns/day"].max() or 50

--- a/mdbenchmark/tests/test_plot.py
+++ b/mdbenchmark/tests/test_plot.py
@@ -35,6 +35,27 @@ from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
 from matplotlib.figure import Figure
 
 
+@pytest.mark.parametrize(
+    "size,min_x,plot_cores,xtick_step,xsteps",
+    [
+        [10, 1, False, None, 1],
+        [18, 1, False, None, 2],
+        [10, 1, True, None, 1],
+        [11, 1, True, None, 3],
+        [5, 100, True, None, 3],
+        [5, 1, False, 5, 5],
+    ],
+)
+def test_get_xsteps(size, min_x, plot_cores, xtick_step, xsteps):
+    """Test the get_xsteps function"""
+    assert (
+        plot.get_xsteps(
+            size=size, min_x=min_x, plot_cores=plot_cores, xtick_step=xtick_step
+        )
+        == xsteps
+    )
+
+
 def test_plot_gpu(cli_runner, tmpdir, data):
     """Test gpu flage without any host or module.
     """

--- a/mdbenchmark/tests/test_plot.py
+++ b/mdbenchmark/tests/test_plot.py
@@ -20,19 +20,18 @@
 import os
 
 import click
+
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
-from numpy.testing import assert_equal
-from pandas.testing import assert_frame_equal
-
+from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
+from matplotlib.figure import Figure
 from mdbenchmark import cli, plot, utils
 from mdbenchmark.ext.click_test import cli_runner
 from mdbenchmark.testing import data
-
-import matplotlib.pyplot as plt
-from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
-from matplotlib.figure import Figure
+from numpy.testing import assert_equal
+from pandas.testing import assert_frame_equal
 
 
 @pytest.mark.parametrize(
@@ -321,7 +320,7 @@ def test_plot_plot_line(capsys, cli_runner, tmpdir, data):
     fig = Figure()
     FigureCanvas(fig)
     ax = fig.add_subplot(111)
-    plot.plot_line(df=df, selection=selection, label=label, ax=ax)
+    plot.plot_line(df=df, selection=selection, label=label, fit=True, ax=ax)
 
 
 def test_plot_plot_line_singlepoint(capsys, cli_runner, tmpdir, data):
@@ -334,4 +333,4 @@ def test_plot_plot_line_singlepoint(capsys, cli_runner, tmpdir, data):
     fig = Figure()
     FigureCanvas(fig)
     ax = fig.add_subplot(111)
-    plot.plot_line(df=df, selection=selection, label=label, ax=ax)
+    plot.plot_line(df=df, selection=selection, label=label, fit=True, ax=ax)


### PR DESCRIPTION
Fixes #96.

Changes made in this pull request:
- Added option to set the plot DPI via `--dpi`.
- Added option to set the plot font size via `--font-size`.
- Added option to hide the linear scaling fit via `--no-fit`.
- Added saner defaults for `ylim`.
- Added custom `xticks` and `yticks` depending on the number of nodes/cores used and the benchmarks' performance.
- `xtick` steps can be overwritten with the option `--xtick-step`.
- Added a watermark (text: `MDBenchmark`) to the top left of the plot. It's added to every plot by default, but can easily be switched off with `--no-watermark`.

PR Checklist
------------
 - [x] Added changelog fragment in  `./changelog/` ([more information](https://github.com/bio-phys/MDBenchmark/blob/master/DEVELOPER.rst#using-towncrier))?
 - [x] Issue raised/referenced?
