### PR TITLE
Make generate work with relative file paths

### DIFF
--- a/changelog/124.bugfix.1
+++ b/changelog/124.bugfix.1
@@ -1,0 +1,1 @@
+Fixed a bug where benchmark creation with files ending in ``.namd`` did not work.

--- a/changelog/124.bugfix.2
+++ b/changelog/124.bugfix.2
@@ -1,0 +1,1 @@
+Fixed a bug where benchmark creation would fail when the input file was not in the current directory.

--- a/mdbenchmark/generate.py
+++ b/mdbenchmark/generate.py
@@ -17,6 +17,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with MDBenchmark.  If not, see <http://www.gnu.org/licenses/>.
+import os.path
+
 import click
 
 import datreant as dtr
@@ -312,6 +314,7 @@ def generate(
         console.error("Exiting. No benchmarks generated.")
 
     for index, row in df_overview.iterrows():
+        relative_path, file_basename = os.path.split(row["name"])
         write_benchmark(
             engine=row["engine"],
             base_directory=row["base_directory"],
@@ -319,7 +322,8 @@ def generate(
             nodes=row["nodes"],
             gpu=row["gpu"],
             module=row["module"],
-            name=row["name"],
+            name=file_basename,
+            relative_path=relative_path,
             job_name=row["job_name"],
             host=row["host"],
             time=row["run time [min]"],

--- a/mdbenchmark/mdengines/gromacs.py
+++ b/mdbenchmark/mdengines/gromacs.py
@@ -31,7 +31,7 @@ from .. import console
 NAME = "gromacs"
 
 
-def prepare_benchmark(name, *args, **kwargs):
+def prepare_benchmark(name, relative_path, *args, **kwargs):
     sim = kwargs["sim"]
 
     full_filename = name + ".tpr"
@@ -39,7 +39,9 @@ def prepare_benchmark(name, *args, **kwargs):
         full_filename = name
         name = name[:-4]
 
-    copyfile(full_filename, sim[full_filename].relpath)
+    filepath = os.path.join(relative_path, full_filename)
+
+    copyfile(filepath, sim[full_filename].relpath)
 
     return name
 

--- a/mdbenchmark/mdengines/namd.py
+++ b/mdbenchmark/mdengines/namd.py
@@ -29,7 +29,7 @@ from .. import console
 NAME = "namd"
 
 
-def prepare_benchmark(name, *args, **kwargs):
+def prepare_benchmark(name, relative_path, *args, **kwargs):
     sim = kwargs["sim"]
 
     if name.endswith(".namd"):
@@ -39,13 +39,17 @@ def prepare_benchmark(name, *args, **kwargs):
     psf = "{}.psf".format(name)
     pdb = "{}.pdb".format(name)
 
-    with open(namd) as fh:
+    namd_relpath = os.path.join(relative_path, namd)
+    psf_relpath = os.path.join(relative_path, psf)
+    pdb_relpath = os.path.join(relative_path, pdb)
+
+    with open(namd_relpath) as fh:
         analyze_namd_file(fh)
         fh.seek(0)
 
-    copyfile(namd, sim[namd].relpath)
-    copyfile(psf, sim[psf].relpath)
-    copyfile(pdb, sim[pdb].relpath)
+    copyfile(namd_relpath, sim[namd].relpath)
+    copyfile(psf_relpath, sim[psf].relpath)
+    copyfile(pdb_relpath, sim[pdb].relpath)
 
     return name
 
@@ -78,7 +82,7 @@ def check_input_file_exists(name):
     # Check whether the needed files are there.
     for extension in ["namd", "psf", "pdb"]:
         if name.endswith(".{}".format(extension)):
-            name = name[: -2 + len(extension)]
+            name = name[: -1 - len(extension)]
 
         fn = "{}.{}".format(name, extension)
         if not os.path.exists(fn):

--- a/mdbenchmark/mdengines/utils.py
+++ b/mdbenchmark/mdengines/utils.py
@@ -151,14 +151,24 @@ def cleanup_before_restart(engine, sim):
 
 
 def write_benchmark(
-    engine, base_directory, template, nodes, gpu, module, name, job_name, host, time
+    engine,
+    base_directory,
+    template,
+    nodes,
+    gpu,
+    module,
+    name,
+    relative_path,
+    job_name,
+    host,
+    time,
 ):
     """Generate a benchmark folder with the respective Sim object."""
     # Create the `dtr.Treant` object
     sim = dtr.Treant(base_directory["{}/".format(nodes)])
 
     # Do MD engine specific things. Here we also format the name.
-    name = engine.prepare_benchmark(name=name, sim=sim)
+    name = engine.prepare_benchmark(name=name, relative_path=relative_path, sim=sim)
     if job_name is None:
         job_name = name
 


### PR DESCRIPTION
Fixes #120.

Changes made in this pull request:
- Fixed a bug, where running `mdbenchmark generate --name ../md.tpr` would copy the file `md.tpr` to the wrong destination folder.
- Fixed a bug where specifying `mdbenchmark generate --name md.namd` would not parse the file name correctly.

PR Checklist
------------
 - [x] Added changelog fragment in  `./changelog/` ([more information](https://github.com/bio-phys/MDBenchmark/blob/master/DEVELOPER.rst#using-towncrier))?
 - [x] Issue raised/referenced?
