### PR TITLE
Let user change the job name of benchmarks

### DIFF
--- a/mdbenchmark/generate.py
+++ b/mdbenchmark/generate.py
@@ -187,10 +187,23 @@ def validate_hosts(ctx, param, host=None):
     is_flag=True,
 )
 @click.option(
+    "--job-name", help="Give an optional to the generated benchmarks.", default=None
+)
+@click.option(
     "-y", "--yes", help="Answer all prompts with yes.", default=False, is_flag=True
 )
 def generate(
-    name, cpu, gpu, module, host, min_nodes, max_nodes, time, skip_validation, yes
+    name,
+    cpu,
+    gpu,
+    module,
+    host,
+    min_nodes,
+    max_nodes,
+    time,
+    skip_validation,
+    job_name,
+    yes,
 ):
     """Generate benchmarks for molecular dynamics simulations.
 
@@ -236,6 +249,7 @@ def generate(
     df_overview = pd.DataFrame(
         columns=[
             "name",
+            "job_name",
             "base_directory",
             "template",
             "engine",
@@ -275,6 +289,7 @@ def generate(
             for nodes in range(min_nodes, max_nodes + 1):
                 df_overview.loc[i] = [
                     name,
+                    job_name,
                     base_directory,
                     template,
                     engine,
@@ -305,6 +320,7 @@ def generate(
             gpu=row["gpu"],
             module=row["module"],
             name=row["name"],
+            job_name=row["job_name"],
             host=row["host"],
             time=row["run time [min]"],
         )

--- a/mdbenchmark/mdengines/utils.py
+++ b/mdbenchmark/mdengines/utils.py
@@ -151,7 +151,7 @@ def cleanup_before_restart(engine, sim):
 
 
 def write_benchmark(
-    engine, base_directory, template, nodes, gpu, module, name, host, time
+    engine, base_directory, template, nodes, gpu, module, name, job_name, host, time
 ):
     """Generate a benchmark folder with the respective Sim object."""
     # Create the `dtr.Treant` object
@@ -159,6 +159,8 @@ def write_benchmark(
 
     # Do MD engine specific things. Here we also format the name.
     name = engine.prepare_benchmark(name=name, sim=sim)
+    if job_name is None:
+        job_name = name
 
     # Add categories to the `Sim` object
     sim.categories = {
@@ -178,6 +180,7 @@ def write_benchmark(
     # Create benchmark job script
     script = template.render(
         name=name,
+        job_name=job_name,
         gpu=gpu,
         module=module,
         mdengine=engine.NAME,

--- a/mdbenchmark/templates/cobra
+++ b/mdbenchmark/templates/cobra
@@ -1,11 +1,11 @@
 #!/bin/bash -l
 # Standard output and error:
-#SBATCH -o ./{{ name }}.out.%j
-#SBATCH -e ./{{ name }}.err.%j
+#SBATCH -o ./{{ job_name }}.out.%j
+#SBATCH -e ./{{ job_name }}.err.%j
 # Initial working directory:
 #SBATCH -D ./
 # Job Name:
-#SBATCH -J {{ name }}
+#SBATCH -J {{ job_name }}
 #
 # Queue (Partition):
 {%- if (time <= 30) and (n_nodes <= 32) %}

--- a/mdbenchmark/templates/draco
+++ b/mdbenchmark/templates/draco
@@ -1,11 +1,11 @@
 #!/bin/bash -l
 # Standard output and error:
-#SBATCH -o ./{{ name }}.out.%j
-#SBATCH -e ./{{ name }}.err.%j
+#SBATCH -o ./{{ job_name }}.out.%j
+#SBATCH -e ./{{ job_name }}.err.%j
 # Initial working directory:
 #SBATCH -D ./
 # Job Name:
-#SBATCH -J {{ name }}
+#SBATCH -J {{ job_name }}
 #
 # Queue (Partition):
 {%- if gpu %}

--- a/mdbenchmark/templates/hydra
+++ b/mdbenchmark/templates/hydra
@@ -1,8 +1,8 @@
 #!/bin/bash -l
 # @ shell=/bin/bash
 #
-# @ error = {{ name }}.err.$(jobid)
-# @ output = {{ name }}.out.$(jobid)
+# @ error = {{ job_name }}.err.$(jobid)
+# @ output = {{ job_name }}.out.$(jobid)
 # @ job_type = parallel
 # @ node_usage = not_shared
 # @ node = {{ n_nodes }}


### PR DESCRIPTION
Fixes #85

Changes made in this pull request:
- Added `--job-name` option to `mdbenchmark generate`.


PR Checklist
------------
 - [ ] Added changelog fragment in  `./changelog/` ([more information](https://github.com/bio-phys/MDBenchmark/blob/master/DEVELOPER.rst#using-towncrier))?
 - [x] Issue raised/referenced?
