### PR TITLE
Run isort during Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
       install:
         - $UPGRADE_PIP
         - pip install isort
-      script: make isort
+      script: make isort-check
     - name: "Lint reStructuredText"
       install:
         - $UPGRADE_PIP

--- a/mdbenchmark/analyze.py
+++ b/mdbenchmark/analyze.py
@@ -18,7 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with MDBenchmark.  If not, see <http://www.gnu.org/licenses/>.
 import click
-
 import datreant as dtr
 import matplotlib.pyplot as plt
 import numpy as np

--- a/mdbenchmark/console.py
+++ b/mdbenchmark/console.py
@@ -17,10 +17,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with MDBenchmark.  If not, see <http://www.gnu.org/licenses/>.
+import six
+
 import sys
 
 import click
-import six
 
 
 def console_wrapper(

--- a/mdbenchmark/generate.py
+++ b/mdbenchmark/generate.py
@@ -20,7 +20,6 @@
 import os.path
 
 import click
-
 import datreant as dtr
 import pandas as pd
 

--- a/mdbenchmark/mdengines/__init__.py
+++ b/mdbenchmark/mdengines/__init__.py
@@ -17,13 +17,13 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with MDBenchmark.  If not, see <http://www.gnu.org/licenses/>.
+import six
+
 import os
 from collections import defaultdict
 
-import six
-
-from . import gromacs, namd
 from .. import console
+from . import gromacs, namd
 
 SUPPORTED_ENGINES = {"gromacs": gromacs, "namd": namd}
 

--- a/mdbenchmark/plot.py
+++ b/mdbenchmark/plot.py
@@ -18,7 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with MDBenchmark.  If not, see <http://www.gnu.org/licenses/>.
 import click
-
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd

--- a/mdbenchmark/submit.py
+++ b/mdbenchmark/submit.py
@@ -22,7 +22,6 @@ import subprocess
 from glob import glob
 
 import click
-
 import datreant as dtr
 import numpy as np
 import pandas as pd

--- a/mdbenchmark/tests/mdengines/test_gromacs.py
+++ b/mdbenchmark/tests/mdengines/test_gromacs.py
@@ -22,6 +22,7 @@ from six.moves import StringIO
 import datreant as dtr
 import numpy as np
 import pytest
+
 from mdbenchmark.mdengines import gromacs, utils
 
 

--- a/mdbenchmark/tests/mdengines/test_namd.py
+++ b/mdbenchmark/tests/mdengines/test_namd.py
@@ -22,6 +22,7 @@ from six.moves import StringIO
 import datreant as dtr
 import numpy as np
 import pytest
+
 from mdbenchmark.mdengines import namd, utils
 
 

--- a/mdbenchmark/tests/mdengines/test_utils.py
+++ b/mdbenchmark/tests/mdengines/test_utils.py
@@ -22,6 +22,7 @@ from glob import glob
 
 import datreant as dtr
 import pytest
+
 from mdbenchmark.mdengines import gromacs, namd, utils
 from mdbenchmark.utils import retrieve_host_template
 

--- a/mdbenchmark/tests/migrations/test_mds_to_dtr.py
+++ b/mdbenchmark/tests/migrations/test_mds_to_dtr.py
@@ -22,6 +22,7 @@ import uuid
 
 import datreant as dtr
 import pytest
+
 from mdbenchmark.migrations import mds_to_dtr
 
 

--- a/mdbenchmark/tests/test_analyze.py
+++ b/mdbenchmark/tests/test_analyze.py
@@ -22,10 +22,11 @@ import os
 import datreant as dtr
 import numpy as np
 import pandas as pd
-from mdbenchmark.utils import PrintDataFrame, ConsolidateDataFrame, DataFrameFromBundle
+
 from mdbenchmark import cli
 from mdbenchmark.ext.click_test import cli_runner
 from mdbenchmark.testing import data, datafiles
+from mdbenchmark.utils import ConsolidateDataFrame, DataFrameFromBundle, PrintDataFrame
 
 
 def test_analyze_gromacs(cli_runner, tmpdir, data):

--- a/mdbenchmark/tests/test_console.py
+++ b/mdbenchmark/tests/test_console.py
@@ -17,8 +17,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with MDBenchmark.  If not, see <http://www.gnu.org/licenses/>.
-import pytest
 from six import StringIO
+
+import pytest
 
 from mdbenchmark import console
 

--- a/mdbenchmark/tests/test_generate.py
+++ b/mdbenchmark/tests/test_generate.py
@@ -19,13 +19,12 @@
 # along with MDBenchmark.  If not, see <http://www.gnu.org/licenses/>.
 import os
 
-import pytest
+import datreant as dtr
 import pandas as pd
+import pytest
 from click import exceptions
 
-import datreant as dtr
 from mdbenchmark import cli
-from mdbenchmark.utils import DataFrameFromBundle, PrintDataFrame, ConsolidateDataFrame
 from mdbenchmark.ext.click_test import cli_runner
 from mdbenchmark.generate import (
     NAMD_WARNING,
@@ -37,6 +36,7 @@ from mdbenchmark.generate import (
     validate_number_of_nodes,
 )
 from mdbenchmark.mdengines import SUPPORTED_ENGINES
+from mdbenchmark.utils import ConsolidateDataFrame, DataFrameFromBundle, PrintDataFrame
 
 DIR_STRUCTURE = {
     "applications": {

--- a/mdbenchmark/tests/test_plot.py
+++ b/mdbenchmark/tests/test_plot.py
@@ -20,18 +20,18 @@
 import os
 
 import click
-
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
 from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
 from matplotlib.figure import Figure
+from numpy.testing import assert_equal
+from pandas.testing import assert_frame_equal
+
 from mdbenchmark import cli, plot, utils
 from mdbenchmark.ext.click_test import cli_runner
 from mdbenchmark.testing import data
-from numpy.testing import assert_equal
-from pandas.testing import assert_frame_equal
 
 
 @pytest.mark.parametrize(

--- a/mdbenchmark/tests/test_submit.py
+++ b/mdbenchmark/tests/test_submit.py
@@ -17,15 +17,16 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with MDBenchmark.  If not, see <http://www.gnu.org/licenses/>.
-import pytest
-import pandas as pd
 import datreant as dtr
-from mdbenchmark.utils import DataFrameFromBundle, PrintDataFrame
+import pandas as pd
+import pytest
+
 from mdbenchmark import cli
 from mdbenchmark.ext.click_test import cli_runner
 from mdbenchmark.mdengines import gromacs
 from mdbenchmark.submit import get_batch_command
 from mdbenchmark.testing import data
+from mdbenchmark.utils import DataFrameFromBundle, PrintDataFrame
 
 
 def test_get_batch_command(capsys, monkeypatch, tmpdir):

--- a/mdbenchmark/utils.py
+++ b/mdbenchmark/utils.py
@@ -22,7 +22,6 @@ import multiprocessing as mp
 import os
 import socket
 import sys
-from tabulate import tabulate
 
 import click
 import datreant as dtr
@@ -31,11 +30,11 @@ import pandas as pd
 import xdg
 from jinja2 import ChoiceLoader, Environment, FileSystemLoader, PackageLoader
 from jinja2.exceptions import TemplateNotFound
-
-from .mdengines import detect_md_engine, utils
+from tabulate import tabulate
 
 from . import console
 from .ext.cadishi import _cat_proc_cpuinfo_grep_query_sort_uniq
+from .mdengines import detect_md_engine, utils
 
 # Order where to look for host templates: HOME -> etc -> package
 # home

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,11 @@ include_trailing_comma=True
 force_grid_wrap=0
 combine_as_imports=True
 line_length=88
+default_section = THIRDPARTY
+known_first_party = mdbenchmark
+known_future_library = six
+known_third_party = click,datreant,matplotlib,numpy,pandas,tabulate
+sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 
 [coverage:run]
 omit =


### PR DESCRIPTION
We missed to run `isort` in the correct way with Travis-CI. This fixes the issue and reformats a few files.