### PR TITLE
Add GPUs to cobra template

### DIFF
--- a/changelog/142.feature.rst
+++ b/changelog/142.feature.rst
@@ -1,0 +1,1 @@
+ Add GPUs to cobra template.

--- a/mdbenchmark/templates/cobra
+++ b/mdbenchmark/templates/cobra
@@ -8,7 +8,11 @@
 #SBATCH -J {{ job_name }}
 #
 # Queue (Partition):
-{%- if (time <= 30) and (n_nodes <= 32) %}
+{%- if gpu %}
+#SBATCH --partition=gpu
+#SBATCH --constraint="gpu"
+#SBATCH --gres=gpu:2 
+{%- elif (time <= 30) and (n_nodes <= 32) %}
 #SBATCH --partition=express
 {%- elif (n_nodes <= 32) %}
 #SBATCH --partition=medium


### PR DESCRIPTION
The MPCDF `cobra` cluster was equipped with Tesla V100 GPUs in December 2018. These are accessible on the `gpu` partition. This PR adds the functionality to run benchmarks with GPUs on `cobra`.

Changes made in this pull request:
- Added GPU functionality to `cobra` template. 

PR Checklist
------------
 - [ ] Added changelog fragment in  `./changelog/` ([more information](https://github.com/bio-phys/MDBenchmark/blob/master/DEVELOPER.rst#using-towncrier))?
