### PR TITLE
(docs) Instructions on adding new engines

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -101,6 +101,7 @@ Content
    analyze
    plot
    jobtemplates
+   mdengine
 
 Usage reference
 ===============

--- a/docs/mdengine.rst
+++ b/docs/mdengine.rst
@@ -1,0 +1,90 @@
+Adding new MD engines
+======================
+
+If you need to add a new simulation engine to MDBenchmark that is not
+yet supported, follow the steps below.
+
+Set up local environment
+------------------------
+
+.. note::
+
+  Make sure that you have `poetry`_ installed. We use it to provision the local
+  development environment.
+
+First, clone the ``git`` repository and enter the directory::
+
+  git clone https://github.com/bio-phys/MDBenchmark.git
+  cd MDBenchmark
+
+.. _poetry: https://github.com/python-poetry/poetry
+
+Install the development dependencies using ``poetry``::
+
+  poetry install
+
+You can now run ``mdbenchmark`` with ``poetry``::
+
+  poetry run mdbenchmark
+
+Create the new engine
+---------------------
+
+You can now add a new MD engine to the ``mdbenchmark/mdengines`` folder. Create
+a file with the name of the engine, i.e., ``openmm.py``.
+
+This new file must implement the functions ``prepare_benchmarks()`` and
+``check_input_file_exists()``. For reference, refer to the paragraphs below and
+the implementations of other engines.
+
+``prepare_benchmarks()``
+_________________________
+
+This function extracts the filename (``md`` from ``md.tpr``) and copies the files required to run each
+benchmark into the correct location. It receives the filename (``name``), i.e.,
+``md.tpr`` and the relative path (``relative_path``) to the benchmark folder
+about to be generated as arguments.
+
+``check_input_file_exists()``
+_____________________________
+
+This function should assert that all files needed to run a benchmark with the
+given engine exist. It receives the flename (``name``), i.e., ``md.tpr`` as
+argument.
+
+Add log file parser
+-------------------
+
+MDBenchmark needs to know how to extract the performance from the log file that
+is produced by the MD engine. Therefore you need to add your engine to the
+`PARSE_ENGINE` dictionary in ``mdbenchmark/mdengines/utils.py``.
+
+The keys inside each engine dictionary have specific functions:
+
++--------------------+-------------------------------------------------------------------+
+| Key                | Description                                                       |
++====================+===================================================================+
+| performance        | Start of the line containing the performance                      |
++--------------------+-------------------------------------------------------------------+
+| performance_return | A lambda function to extract the performance value                |
++--------------------+-------------------------------------------------------------------+
+| ncores             | Start of the line containing the number of cores used for the run |
++--------------------+-------------------------------------------------------------------+
+| ncores_return      | A lambda function to extract the number of cores                  |
++--------------------+-------------------------------------------------------------------+
+| analyze            | A regular expression for the output file to parse                 |
++--------------------+-------------------------------------------------------------------+
+
+Add cleanup exceptions
+----------------------
+
+Submitting a benchmark via ``mdbenchmark submit --force`` will delete all
+previous results. You need to define all files that need to be kept in the
+`FILES_TO_KEEP` dictionary in ``mdbenchmark/mdengines/utils.py``.
+
+Register the engine
+-------------------
+
+Finally you need to register the engine with MDBenchmark. To do this, import the
+engine in ``mdbenchmark/mdengines/__init__.py`` and add it into the
+``SUPPORTED_ENGINES`` dictionary.

--- a/mdbenchmark/cli/plot.py
+++ b/mdbenchmark/cli/plot.py
@@ -26,6 +26,7 @@ from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
 from matplotlib.figure import Figure
 
 from mdbenchmark import console
+from mdbenchmark.mdengines import SUPPORTED_ENGINES
 from mdbenchmark.utils import calc_slope_intercept, generate_output_name, lin_func
 
 plt.switch_backend("agg")
@@ -148,7 +149,7 @@ def filter_dataframe_for_plotting(df, host_name, module_name, gpu, cpu):
         )
 
     for module in module_name:
-        if module in ["gromacs", "namd"]:
+        if module in SUPPORTED_ENGINES.keys():
             console.info("Plotting all modules for engine '{}'.", module)
         elif module in df["module"].tolist():
             console.info("Plotting module '{}'.", module)

--- a/mdbenchmark/mdengines/__init__.py
+++ b/mdbenchmark/mdengines/__init__.py
@@ -120,7 +120,9 @@ def normalize_modules(modules, skip_validation):
         if detect_md_engine(engine_name) is None:
             console.error(
                 "There is currently no support for '{}'. "
-                "Supported MD engines are: gromacs, namd.",
+                "Supported MD engines are: {}.".format(
+                    ", ".join(SUPPORTED_ENGINES.keys())
+                ),
                 engine_name,
             )
 

--- a/mdbenchmark/mdengines/__init__.py
+++ b/mdbenchmark/mdengines/__init__.py
@@ -120,8 +120,8 @@ def normalize_modules(modules, skip_validation):
         if detect_md_engine(engine_name) is None:
             console.error(
                 "There is currently no support for '{}'. "
-                "Supported MD engines are: {}.".format(
-                    ", ".join(SUPPORTED_ENGINES.keys())
+                + "Supported MD engines are: {}.".format(
+                    ", ".join(sorted(SUPPORTED_ENGINES.keys()))
                 ),
                 engine_name,
             )


### PR DESCRIPTION
Changes made in this pull request:
- Added a new documentation page on how to add a new engine to MDBenchmark.

@MSiggel Could you please check the new page (`mdengine.rst`) for typos?